### PR TITLE
Release workflow + download UX polish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,22 +1,19 @@
 name: release
 
 # Builds the Tauri app for macOS (arm64 + x86_64), Windows, and Linux
-# whenever a tag matching v* is pushed, then creates a GitHub release
-# as a draft with the produced installers (.dmg / .msi / .exe /
-# .AppImage / .deb) attached as assets.
+# whenever a tag matching v* is pushed, patches tauri.conf.json to
+# match the tag version, renames bundles to descriptive OS-named
+# files, and attaches them to a draft GitHub release.
 #
-# Trigger: `git tag v0.1.0 && git push origin v0.1.0` (or create the
-# tag via the GitHub UI). Review the draft release, then publish.
+# Trigger: `git tag v0.1.0 && git push origin v0.1.0`. Review the
+# draft release in the GitHub UI, then publish.
 
 on:
   push:
     tags:
       - 'v*'
-  # Also allow manual runs without a tag (for debugging the workflow itself).
   workflow_dispatch:
 
-# Only one release build per ref at a time; cancel stale runs if a
-# new release supersedes the old one.
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: true
@@ -29,19 +26,19 @@ jobs:
         include:
           - os: macos-latest
             target: aarch64-apple-darwin
-            label: macos-arm64
+            label: macOS-AppleSilicon
           - os: macos-13
             target: x86_64-apple-darwin
-            label: macos-x64
+            label: macOS-Intel
           - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
-            label: linux-x64
+            label: Linux-x86_64
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            label: windows-x64
+            label: Windows-x86_64
     runs-on: ${{ matrix.os }}
     permissions:
-      contents: write  # needed to upload release assets
+      contents: write
 
     steps:
       - name: Checkout
@@ -84,33 +81,61 @@ jobs:
             file \
             libxdo-dev
 
+      - name: Resolve version from tag
+        id: ver
+        shell: bash
+        run: |
+          REF="${GITHUB_REF_NAME:-v0.0.0-dev}"
+          echo "version=${REF#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Patch tauri.conf.json version
+        shell: bash
+        run: |
+          node -e "const fs=require('fs');const p='src-tauri/tauri.conf.json';const j=JSON.parse(fs.readFileSync(p));j.version='${{ steps.ver.outputs.version }}';fs.writeFileSync(p,JSON.stringify(j,null,2)+'\n');"
+          grep '"version"' src-tauri/tauri.conf.json
+
       - name: Install JS deps
         run: pnpm install --frozen-lockfile
 
-      - name: Build Tauri app and upload to release
-        uses: tauri-apps/tauri-action@v0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tagName: ${{ github.ref_name }}
-          releaseName: 'Ante ${{ github.ref_name }}'
-          releaseBody: 'See the assets below to download and install. Unsigned builds - macOS users may need `xattr -d com.apple.quarantine /Applications/ante.app`.'
-          releaseDraft: true
-          prerelease: false
-          args: --target ${{ matrix.target }}
+      - name: Build Tauri app
+        run: pnpm tauri build --target ${{ matrix.target }}
 
-      # When this workflow is run via workflow_dispatch (no release), upload
-      # the built bundle as a workflow artifact instead so you can still
-      # grab the installers without needing a release.
-      - name: Upload debug artifact (workflow_dispatch only)
+      - name: Stage renamed artifacts
+        shell: bash
+        run: |
+          mkdir -p artifacts
+          L="${{ matrix.label }}"
+          BD="src-tauri/target/${{ matrix.target }}/release/bundle"
+          shopt -s nullglob
+          for src in "$BD"/dmg/*.dmg; do cp "$src" "artifacts/ante-${L}.dmg"; done
+          for src in "$BD"/deb/*.deb; do cp "$src" "artifacts/ante-${L}.deb"; done
+          for src in "$BD"/appimage/*.AppImage; do cp "$src" "artifacts/ante-${L}.AppImage"; done
+          for src in "$BD"/msi/*.msi; do cp "$src" "artifacts/ante-${L}.msi"; done
+          for src in "$BD"/nsis/*.exe; do cp "$src" "artifacts/ante-${L}-Setup.exe"; done
+          ls -la artifacts/
+
+      - name: Upload to draft release
+        if: github.event_name == 'push'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: 'Ante ${{ github.ref_name }}'
+          draft: true
+          generate_release_notes: true
+          body: |
+            Unsigned builds - first launch will be blocked by Gatekeeper / SmartScreen.
+
+            - **macOS**: after install run `xattr -d com.apple.quarantine /Applications/ante.app`
+            - **Windows**: click "More info" -> "Run anyway" on the SmartScreen dialog
+
+            Downloads below, or the "Download" section in the [README](https://github.com/willhama/ante#download) for the always-latest links.
+          files: artifacts/*
+          fail_on_unmatched_files: false
+
+      - name: Upload workflow artifact
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
           name: ante-${{ matrix.label }}
-          path: |
-            src-tauri/target/${{ matrix.target }}/release/bundle/**/*.dmg
-            src-tauri/target/${{ matrix.target }}/release/bundle/**/*.msi
-            src-tauri/target/${{ matrix.target }}/release/bundle/**/*.exe
-            src-tauri/target/${{ matrix.target }}/release/bundle/**/*.AppImage
-            src-tauri/target/${{ matrix.target }}/release/bundle/**/*.deb
+          path: artifacts/
           if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -18,17 +18,45 @@ It is not trying to be Word. It is trying to be the thing you reach for when you
 
 ## Download
 
-Grab the latest release for your platform:
+All download buttons point to the latest release page; pick the file for your platform there.
 
-[![macOS (Apple Silicon)](https://img.shields.io/badge/macOS-Apple%20Silicon-000000?style=for-the-badge&logo=apple&logoColor=white)](https://github.com/willhama/ante/releases/latest/download/ante-macOS-AppleSilicon.dmg)
-[![macOS (Intel)](https://img.shields.io/badge/macOS-Intel-000000?style=for-the-badge&logo=apple&logoColor=white)](https://github.com/willhama/ante/releases/latest/download/ante-macOS-Intel.dmg)
-[![Windows (x64)](https://img.shields.io/badge/Windows-x64-0078D4?style=for-the-badge&logo=windows&logoColor=white)](https://github.com/willhama/ante/releases/latest/download/ante-Windows-x86_64-Setup.exe)
-[![Linux (AppImage)](https://img.shields.io/badge/Linux-AppImage-FCC624?style=for-the-badge&logo=linux&logoColor=black)](https://github.com/willhama/ante/releases/latest/download/ante-Linux-x86_64.AppImage)
-[![Linux (Deb)](https://img.shields.io/badge/Linux-deb-FCC624?style=for-the-badge&logo=debian&logoColor=white)](https://github.com/willhama/ante/releases/latest/download/ante-Linux-x86_64.deb)
+[![macOS](https://img.shields.io/badge/macOS-Download-000000?style=for-the-badge&logo=apple&logoColor=white)](https://github.com/willhama/ante/releases/latest)
+[![Windows](https://img.shields.io/badge/Windows-Download-0078D4?style=for-the-badge&logo=windows&logoColor=white)](https://github.com/willhama/ante/releases/latest)
+[![Linux](https://img.shields.io/badge/Linux-Download-FCC624?style=for-the-badge&logo=linux&logoColor=black)](https://github.com/willhama/ante/releases/latest)
 
 [All releases](https://github.com/willhama/ante/releases)
 
-Builds are currently unsigned. On macOS, run `xattr -d com.apple.quarantine /Applications/ante.app` after installing. On Windows, click "More info" then "Run anyway" on the SmartScreen prompt.
+Builds are currently unsigned. You will need to bypass Gatekeeper / SmartScreen on first launch.
+
+### Install on macOS
+
+1. Download `ante-macOS-AppleSilicon.dmg` (M1/M2/M3/M4 Macs) or `ante-macOS-Intel.dmg` (older Intel Macs).
+2. Open the `.dmg` and drag `ante.app` to your Applications folder.
+3. Because the build is unsigned, macOS will refuse to open it on first launch ("ante is damaged and can't be opened"). Remove the quarantine flag from Terminal:
+   ```bash
+   xattr -dr com.apple.quarantine /Applications/ante.app
+   ```
+4. Launch ante from Applications. Subsequent launches work normally.
+
+### Install on Windows
+
+1. Download `ante-Windows-x86_64-Setup.exe` (recommended) or `ante-Windows-x86_64.msi`.
+2. Double-click to run. SmartScreen will show "Windows protected your PC".
+3. Click **More info**, then **Run anyway**.
+4. Follow the installer prompts. ante is added to your Start menu.
+
+### Install on Linux
+
+1. Download `ante-Linux-x86_64.AppImage` (portable) or `ante-Linux-x86_64.deb` (Debian/Ubuntu).
+2. **AppImage**: make it executable and run.
+   ```bash
+   chmod +x ante-Linux-x86_64.AppImage
+   ./ante-Linux-x86_64.AppImage
+   ```
+3. **Deb**: install via `apt`.
+   ```bash
+   sudo apt install ./ante-Linux-x86_64.deb
+   ```
 
 ## Status
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,20 @@ It is not trying to be Word. It is trying to be the thing you reach for when you
   <img src="demo-gif.gif" alt="ante demo" width="720">
 </p>
 
+## Download
+
+Grab the latest release for your platform:
+
+[![macOS (Apple Silicon)](https://img.shields.io/badge/macOS-Apple%20Silicon-000000?style=for-the-badge&logo=apple&logoColor=white)](https://github.com/willhama/ante/releases/latest/download/ante-macOS-AppleSilicon.dmg)
+[![macOS (Intel)](https://img.shields.io/badge/macOS-Intel-000000?style=for-the-badge&logo=apple&logoColor=white)](https://github.com/willhama/ante/releases/latest/download/ante-macOS-Intel.dmg)
+[![Windows (x64)](https://img.shields.io/badge/Windows-x64-0078D4?style=for-the-badge&logo=windows&logoColor=white)](https://github.com/willhama/ante/releases/latest/download/ante-Windows-x86_64-Setup.exe)
+[![Linux (AppImage)](https://img.shields.io/badge/Linux-AppImage-FCC624?style=for-the-badge&logo=linux&logoColor=black)](https://github.com/willhama/ante/releases/latest/download/ante-Linux-x86_64.AppImage)
+[![Linux (Deb)](https://img.shields.io/badge/Linux-deb-FCC624?style=for-the-badge&logo=debian&logoColor=white)](https://github.com/willhama/ante/releases/latest/download/ante-Linux-x86_64.deb)
+
+[All releases](https://github.com/willhama/ante/releases)
+
+Builds are currently unsigned. On macOS, run `xattr -d com.apple.quarantine /Applications/ante.app` after installing. On Windows, click "More info" then "Run anyway" on the SmartScreen prompt.
+
 ## Status
 
 Early. Usable for plain prose. Expect rough edges while the core settles.


### PR DESCRIPTION
## Summary

- Release workflow now patches `src-tauri/tauri.conf.json` version from the pushed tag so the built binary metadata matches the release.
- Bundles are renamed to stable, descriptive OS-named filenames (`ante-macOS-AppleSilicon.dmg`, `ante-Windows-x86_64-Setup.exe`, etc.) before upload.
- Upload switched from tauri-action to softprops/action-gh-release so we can attach the renamed files to a draft release with auto-generated notes.
- README gets three download buttons (macOS / Windows / Linux) all linking to `/releases/latest`, plus step-by-step install instructions covering the Gatekeeper and SmartScreen bypasses for unsigned builds.

## Test plan

- [x] Cut a throwaway tag (e.g. `v0.0.1-test`) to verify the workflow builds all four targets and attaches the renamed assets to a draft release.
- [x] Confirm `src-tauri/tauri.conf.json` version matches the tag in a downloaded binary's About dialog.
- [x] Smoke-test each installer path: macOS quarantine bypass, Windows SmartScreen override, Linux AppImage chmod.
- [x] Delete the test tag / release after verification.