### PR TITLE
Save As button + window-title capability fix

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "core:window:allow-destroy",
+    "core:window:allow-set-title",
     "dialog:default",
     {
       "identifier": "opener:allow-open-url",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -12,7 +12,7 @@
   "app": {
     "windows": [
       {
-        "title": "Untitled - ante",
+        "title": "ANTE - AI Native Text Editor",
         "width": 1200,
         "height": 900
       }

--- a/src/lib/ui/Toolbar.svelte
+++ b/src/lib/ui/Toolbar.svelte
@@ -9,10 +9,11 @@
     onNew?: () => void;
     onOpen?: () => void;
     onSave?: () => void;
+    onSaveAs?: () => void;
     onToggleAi?: () => void;
   }
 
-  let { editor, onNew, onOpen, onSave, onToggleAi }: Props = $props();
+  let { editor, onNew, onOpen, onSave, onSaveAs, onToggleAi }: Props = $props();
 
   function setPageSize(e: Event): void {
     appState.pageSize = (e.target as HTMLSelectElement).value as PageSize;
@@ -175,6 +176,19 @@
         <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"></path>
         <polyline points="17 21 17 13 7 13 7 21"></polyline>
         <polyline points="7 3 7 8 15 8"></polyline>
+      </svg>
+    </button>
+    <button
+      class="toolbar-btn"
+      title="Save As... (Cmd+Shift+S)"
+      onclick={onSaveAs}
+      aria-label="Save As"
+    >
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M17 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h10l4 4v5"></path>
+        <polyline points="14 21 14 13 7 13 7 18"></polyline>
+        <polyline points="7 3 7 8 13 8"></polyline>
+        <path d="M18.5 14.5l3 3-4 4h-3v-3z"></path>
       </svg>
     </button>
   </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -227,6 +227,7 @@
     onNew={handleNew}
     onOpen={handleOpen}
     onSave={handleSave}
+    onSaveAs={() => saveFileAs(getBridge())}
     onToggleAi={toggleAi}
   />
   <PageStack {contentHeight} {pageBreaks}>


### PR DESCRIPTION
## Summary

- **fix(#1)**: Grant `core:window:allow-set-title` in `capabilities/default.json`. Without it, `getCurrentWindow().setTitle()` is silently rejected and the window title stays at the static value from `tauri.conf.json`. Reactive title pipeline (`appState.windowTitle` -> `\$effect` in `+layout.svelte`) was already in place, just blocked at the IPC boundary.
- **feat**: Adds an explicit Save As button to the toolbar (disk + pencil icon, right of Save). Tooltip surfaces the existing `Cmd+Shift+S` shortcut. Wires through to the already-implemented `saveFileAs` flow in `file-ops.ts`.
- **chore**: Updates the static window title in `tauri.conf.json` to "ANTE - AI Native Text Editor". The reactive title overrides this once the editor mounts.

## Test plan

- [ ] After `pnpm tauri dev`, save an untitled doc via the new Save As button -> native dialog appears -> picking a name updates the OS window title to `<filename> - ante`.
- [ ] `Cmd+S` on an untitled doc still triggers Save As (existing fallback).
- [ ] `Cmd+S` on an already-saved doc saves to the same path without showing a dialog.
- [ ] `Cmd+Shift+S` keybind still works for Save As.