### PR TITLE
File explorer sidebar (#11)

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -19,6 +19,85 @@ pub struct SaveAsResult {
     pub path: String,
 }
 
+#[derive(Serialize)]
+pub struct DirEntryInfo {
+    pub name: String,
+    pub path: String,
+    pub is_dir: bool,
+}
+
+/// Maximum number of entries returned from list_directory. Prevents pathological
+/// folder reads (node_modules, etc.) from flooding the renderer.
+const MAX_DIR_ENTRIES: usize = 500;
+
+/// List the immediate children of a directory. If `path` is a file, lists its
+/// parent directory instead. Skips dotfiles. Sorted: directories first, then
+/// files, alphabetical within each group. Capped at MAX_DIR_ENTRIES.
+#[tauri::command]
+pub async fn list_directory(path: String) -> Result<Vec<DirEntryInfo>, AnteError> {
+    let p = std::path::Path::new(&path);
+    let dir = if p.is_file() {
+        p.parent()
+            .ok_or_else(|| AnteError::Io("path has no parent".to_string()))?
+            .to_path_buf()
+    } else {
+        p.to_path_buf()
+    };
+
+    let mut entries: Vec<DirEntryInfo> = Vec::new();
+    let mut read = tokio::fs::read_dir(&dir).await?;
+    while let Some(entry) = read.next_entry().await? {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.starts_with('.') {
+            continue;
+        }
+        let metadata = match entry.metadata().await {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        entries.push(DirEntryInfo {
+            name,
+            path: entry.path().to_string_lossy().to_string(),
+            is_dir: metadata.is_dir(),
+        });
+        if entries.len() >= MAX_DIR_ENTRIES {
+            break;
+        }
+    }
+
+    entries.sort_by(|a, b| match (a.is_dir, b.is_dir) {
+        (true, false) => std::cmp::Ordering::Less,
+        (false, true) => std::cmp::Ordering::Greater,
+        _ => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
+    });
+
+    Ok(entries)
+}
+
+/// Reads a file at the given path. Used by the sidebar to open a file the user
+/// clicked, bypassing the native picker dialog. Same size + UTF-8 + binary
+/// guards as `open_file`.
+#[tauri::command]
+pub async fn read_file(path: String) -> Result<FilePayload, AnteError> {
+    let metadata = tokio::fs::metadata(&path).await?;
+    if metadata.len() > MAX_FILE_SIZE {
+        return Err(AnteError::FileTooLarge(format!(
+            "File is {} bytes (limit: {} bytes)",
+            metadata.len(),
+            MAX_FILE_SIZE
+        )));
+    }
+    let buf = tokio::fs::read(&path).await?;
+    if is_binary(&buf) {
+        return Err(AnteError::BinaryFile(format!(
+            "File appears to be binary: {}",
+            path
+        )));
+    }
+    let contents = validate_utf8(buf, &path)?;
+    Ok(FilePayload { path, contents })
+}
+
 /// Returns true if the buffer contains null bytes in the first BINARY_CHECK_LEN bytes.
 fn is_binary(buf: &[u8]) -> bool {
     let check_len = buf.len().min(BINARY_CHECK_LEN);

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -74,6 +74,39 @@ pub async fn list_directory(path: String) -> Result<Vec<DirEntryInfo>, AnteError
     Ok(entries)
 }
 
+/// Create a new empty `.html` document in the given directory and return the
+/// chosen path. If "Untitled.html" already exists, increments the suffix
+/// ("Untitled 2.html", "Untitled 3.html", ...) until a free name is found.
+/// Writes a minimal empty body so the file appears immediately in directory
+/// listings.
+#[tauri::command]
+pub async fn create_document(dir: String) -> Result<SaveAsResult, AnteError> {
+    let dir_path = std::path::Path::new(&dir);
+    if !dir_path.is_dir() {
+        return Err(AnteError::Io(format!("not a directory: {}", dir)));
+    }
+    let mut chosen: Option<std::path::PathBuf> = None;
+    for n in 0..1000 {
+        let name = if n == 0 {
+            "Untitled.html".to_string()
+        } else {
+            format!("Untitled {}.html", n + 1)
+        };
+        let candidate = dir_path.join(&name);
+        if !candidate.exists() {
+            chosen = Some(candidate);
+            break;
+        }
+    }
+    let path = chosen.ok_or_else(|| {
+        AnteError::Io("could not find a free Untitled name".to_string())
+    })?;
+    tokio::fs::write(&path, b"").await?;
+    Ok(SaveAsResult {
+        path: path.to_string_lossy().to_string(),
+    })
+}
+
 /// Reads a file at the given path. Used by the sidebar to open a file the user
 /// clicked, bypassing the native picker dialog. Same size + UTF-8 + binary
 /// guards as `open_file`.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -107,6 +107,46 @@ pub async fn create_document(dir: String) -> Result<SaveAsResult, AnteError> {
     })
 }
 
+/// Move a file into a destination directory. Preserves the source filename.
+/// Refuses to overwrite an existing target. Tries `rename` first and falls
+/// back to copy + remove if the rename hits a cross-device boundary.
+#[tauri::command]
+pub async fn move_path(src: String, dst_dir: String) -> Result<SaveAsResult, AnteError> {
+    let src_path = std::path::Path::new(&src);
+    let dst_dir_path = std::path::Path::new(&dst_dir);
+    if !src_path.exists() {
+        return Err(AnteError::Io(format!("source does not exist: {}", src)));
+    }
+    if !dst_dir_path.is_dir() {
+        return Err(AnteError::Io(format!(
+            "destination is not a directory: {}",
+            dst_dir
+        )));
+    }
+    let name = src_path
+        .file_name()
+        .ok_or_else(|| AnteError::Io("source has no filename".to_string()))?;
+    let new_path = dst_dir_path.join(name);
+    if new_path == src_path {
+        return Ok(SaveAsResult {
+            path: new_path.to_string_lossy().to_string(),
+        });
+    }
+    if new_path.exists() {
+        return Err(AnteError::Io(format!(
+            "target already exists: {}",
+            new_path.display()
+        )));
+    }
+    if tokio::fs::rename(src_path, &new_path).await.is_err() {
+        tokio::fs::copy(src_path, &new_path).await?;
+        tokio::fs::remove_file(src_path).await?;
+    }
+    Ok(SaveAsResult {
+        path: new_path.to_string_lossy().to_string(),
+    })
+}
+
 /// Reads a file at the given path. Used by the sidebar to open a file the user
 /// clicked, bypassing the native picker dialog. Same size + UTF-8 + binary
 /// guards as `open_file`.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ pub fn run() {
             commands::read_file,
             commands::list_directory,
             commands::create_document,
+            commands::move_path,
             commands::save_file,
             commands::save_file_as,
             ai::stream_completion,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,8 @@ pub fn run() {
         .manage(ai::AiState::default())
         .invoke_handler(tauri::generate_handler![
             commands::open_file,
+            commands::read_file,
+            commands::list_directory,
             commands::save_file,
             commands::save_file_as,
             ai::stream_completion,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ pub fn run() {
             commands::open_file,
             commands::read_file,
             commands::list_directory,
+            commands::create_document,
             commands::save_file,
             commands::save_file_as,
             ai::stream_completion,

--- a/src/lib/state/app-state.svelte.ts
+++ b/src/lib/state/app-state.svelte.ts
@@ -50,6 +50,12 @@ let totalPages = $state<number>(1);
 /** Whether the settings dialog is open. */
 let settingsOpen = $state<boolean>(false);
 
+/** Whether the file-explorer sidebar is visible. */
+let sidebarOpen = $state<boolean>(false);
+
+/** Pixel width of the file-explorer sidebar. */
+let sidebarWidth = $state<number>(240);
+
 /** Trigger speed for ghost autocomplete. Controls debounce + cooldown. */
 export type AiTriggerSpeed = 'eager' | 'balanced' | 'relaxed';
 let aiTriggerSpeed = $state<AiTriggerSpeed>('balanced');
@@ -172,6 +178,12 @@ export const appState = {
 
   get settingsOpen(): boolean { return settingsOpen; },
   set settingsOpen(v: boolean) { settingsOpen = v; },
+
+  get sidebarOpen(): boolean { return sidebarOpen; },
+  set sidebarOpen(v: boolean) { sidebarOpen = v; },
+
+  get sidebarWidth(): number { return sidebarWidth; },
+  set sidebarWidth(v: number) { sidebarWidth = Math.max(160, Math.min(480, v)); },
 
   get aiTriggerSpeed(): AiTriggerSpeed { return aiTriggerSpeed; },
   set aiTriggerSpeed(v: AiTriggerSpeed) { aiTriggerSpeed = v; },

--- a/src/lib/state/file-ops.ts
+++ b/src/lib/state/file-ops.ts
@@ -126,6 +126,36 @@ export async function openFile(bridge: EditorBridge): Promise<void> {
 }
 
 /**
+ * Open a file at a known path (no native dialog). Used by the sidebar.
+ * Prompts to save if the current document is dirty.
+ */
+export async function openPath(path: string, bridge: EditorBridge): Promise<void> {
+  if (appState.isDirty) {
+    const choice = await promptUnsavedChanges();
+    if (choice === 'cancel') return;
+    if (choice === 'save') {
+      await saveFile(bridge);
+      if (appState.isDirty) return;
+    }
+  }
+
+  try {
+    const result = await invoke<FilePayload>('read_file', { path });
+    const { header, footer, stripped } = parseHeaderFooter(result.contents);
+
+    appState.filePath = result.path;
+    appState.headerText = header;
+    appState.footerText = footer;
+    savedSnapshot = stripped;
+    appState.isDirty = false;
+
+    bridge.setHTML(stripped);
+  } catch (err) {
+    await showError(err);
+  }
+}
+
+/**
  * Save the current document to its existing path.
  * If no path exists (untitled), falls through to saveFileAs.
  */

--- a/src/lib/ui/FileExplorer.svelte
+++ b/src/lib/ui/FileExplorer.svelte
@@ -120,6 +120,40 @@
   function createDocumentInRoot(): Promise<void> {
     return createDocumentIn(rootPath);
   }
+
+  async function moveFile(src: string, dstDir: string): Promise<void> {
+    if (!src || !dstDir) return;
+    const srcParent = parentDir(src);
+    if (srcParent === dstDir) return;
+    try {
+      const result = await invoke<{ path: string }>('move_path', {
+        src,
+        dstDir,
+      });
+      const newPath = result.path;
+      // Refresh both ends of the move so they reflect on screen.
+      const dirsToRefresh = new Set<string>([srcParent, dstDir]);
+      for (const dir of dirsToRefresh) {
+        try {
+          const children = await invoke<DirEntry[]>('list_directory', { path: dir });
+          cache.set(dir, children);
+          if (dir === rootPath) {
+            rootEntries = children;
+          }
+        } catch {
+          cache.delete(dir);
+        }
+      }
+      // Auto-expand the destination so the user sees where the file landed.
+      expanded.set(dstDir, true);
+      // If the moved file was the active document, keep it open under its new path.
+      if (appState.filePath === src) {
+        appState.filePath = newPath;
+      }
+    } catch (e) {
+      errorMsg = e instanceof Error ? e.message : 'Failed to move file';
+    }
+  }
 </script>
 
 <aside class="file-explorer" style="width: {appState.sidebarWidth}px">
@@ -166,6 +200,7 @@
             loading={loadingSet}
             {onOpenFile}
             onCreateInFolder={createDocumentIn}
+            onMoveFile={moveFile}
           />
         {/each}
         <button

--- a/src/lib/ui/FileExplorer.svelte
+++ b/src/lib/ui/FileExplorer.svelte
@@ -1,0 +1,285 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { invoke } from '@tauri-apps/api/core';
+  import { appState } from '$lib/state/app-state.svelte';
+
+  interface Props {
+    onOpenFile: (path: string) => void;
+  }
+  const { onOpenFile }: Props = $props();
+
+  interface DirEntry {
+    name: string;
+    path: string;
+    is_dir: boolean;
+  }
+
+  const OPENABLE_EXTS = new Set([
+    'html', 'htm', 'txt', 'md', 'markdown', 'rst', 'log',
+  ]);
+
+  let entries = $state<DirEntry[]>([]);
+  let dirPath = $state<string>('');
+  let loading = $state(false);
+  let errorMsg = $state<string | null>(null);
+
+  const SEP_RX = /[\\/]/;
+
+  function parentDir(path: string): string {
+    const idx = path.search(SEP_RX);
+    if (idx === -1) return '';
+    const lastIdx = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
+    return lastIdx > 0 ? path.slice(0, lastIdx) : path;
+  }
+
+  function basename(path: string): string {
+    const parts = path.split(SEP_RX);
+    return parts[parts.length - 1] || path;
+  }
+
+  function isOpenable(name: string): boolean {
+    const dot = name.lastIndexOf('.');
+    if (dot === -1) return false;
+    return OPENABLE_EXTS.has(name.slice(dot + 1).toLowerCase());
+  }
+
+  async function refresh(targetPath: string): Promise<void> {
+    if (!targetPath) {
+      entries = [];
+      dirPath = '';
+      errorMsg = null;
+      return;
+    }
+    loading = true;
+    errorMsg = null;
+    try {
+      const result = await invoke<DirEntry[]>('list_directory', { path: targetPath });
+      entries = result;
+      dirPath = parentDir(targetPath) || targetPath;
+    } catch (e) {
+      errorMsg = e instanceof Error ? e.message : 'Failed to read directory';
+      entries = [];
+    } finally {
+      loading = false;
+    }
+  }
+
+  // Re-read when active file changes.
+  $effect(() => {
+    refresh(appState.filePath ?? '');
+  });
+
+  const visibleEntries = $derived(
+    entries.filter((e) => e.is_dir || isOpenable(e.name)),
+  );
+
+  const activeFilename = $derived(
+    appState.filePath ? basename(appState.filePath) : null,
+  );
+
+  function handleClick(entry: DirEntry): void {
+    if (entry.is_dir) return;
+    if (entry.path === appState.filePath) return;
+    onOpenFile(entry.path);
+  }
+
+  onMount(() => {
+    refresh(appState.filePath ?? '');
+  });
+</script>
+
+<aside class="file-explorer" style="width: {appState.sidebarWidth}px">
+  <header class="header">
+    <span class="header-title" title={dirPath}>
+      {dirPath ? basename(dirPath) || dirPath : 'No folder'}
+    </span>
+    <button
+      type="button"
+      class="icon-btn"
+      title="Refresh"
+      onclick={() => refresh(appState.filePath ?? '')}
+      aria-label="Refresh"
+    >
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <polyline points="23 4 23 10 17 10"></polyline>
+        <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path>
+      </svg>
+    </button>
+  </header>
+
+  <div class="body">
+    {#if !appState.filePath}
+      <p class="empty">Open a file to see its folder here.</p>
+    {:else if loading && entries.length === 0}
+      <p class="empty">Loading…</p>
+    {:else if errorMsg}
+      <p class="empty error">{errorMsg}</p>
+    {:else if visibleEntries.length === 0}
+      <p class="empty">No openable files in this folder.</p>
+    {:else}
+      <ul class="list">
+        {#each visibleEntries as entry (entry.path)}
+          {@const isActive = entry.name === activeFilename}
+          <li>
+            <button
+              type="button"
+              class="row"
+              class:active={isActive}
+              class:dir={entry.is_dir}
+              disabled={entry.is_dir}
+              onclick={() => handleClick(entry)}
+              title={entry.path}
+            >
+              <span class="row-icon" aria-hidden="true">
+                {#if entry.is_dir}
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path>
+                  </svg>
+                {:else}
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                    <polyline points="14 2 14 8 20 8"></polyline>
+                  </svg>
+                {/if}
+              </span>
+              <span class="row-name">{entry.name}</span>
+            </button>
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  </div>
+</aside>
+
+<style>
+  .file-explorer {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    border-right: 1px solid var(--border-color, rgba(0, 0, 0, 0.08));
+    background: var(--sidebar-bg, var(--background, #f7f7f7));
+    color: var(--foreground, #111);
+    flex-shrink: 0;
+    overflow: hidden;
+    font-size: 13px;
+  }
+
+  .header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 8px 10px;
+    border-bottom: 1px solid var(--border-color, rgba(0, 0, 0, 0.08));
+    background: transparent;
+  }
+
+  .header-title {
+    font-weight: 600;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.4px;
+    color: var(--muted-foreground, #6b7280);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    flex: 1;
+  }
+
+  .icon-btn {
+    display: grid;
+    place-items: center;
+    width: 24px;
+    height: 24px;
+    border: none;
+    background: transparent;
+    color: var(--muted-foreground, #6b7280);
+    border-radius: 4px;
+    cursor: pointer;
+    padding: 0;
+  }
+
+  .icon-btn:hover {
+    background: var(--accent, rgba(0, 0, 0, 0.06));
+    color: var(--foreground, #111);
+  }
+
+  .body {
+    flex: 1;
+    overflow-y: auto;
+    overflow-x: hidden;
+    scrollbar-width: none;
+  }
+
+  .body::-webkit-scrollbar {
+    display: none;
+  }
+
+  .empty {
+    padding: 14px 12px;
+    color: var(--muted-foreground, #6b7280);
+    font-size: 12px;
+    line-height: 1.4;
+  }
+
+  .empty.error {
+    color: #ef4444;
+  }
+
+  .list {
+    list-style: none;
+    margin: 0;
+    padding: 4px 0;
+  }
+
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 5px 12px;
+    border: none;
+    background: transparent;
+    color: inherit;
+    font-size: 13px;
+    text-align: left;
+    cursor: pointer;
+    border-radius: 0;
+  }
+
+  .row:hover:not(:disabled) {
+    background: var(--accent, rgba(0, 0, 0, 0.06));
+  }
+
+  .row.active {
+    background: color-mix(in srgb, var(--primary, #6366f1) 14%, transparent);
+    color: var(--primary, #6366f1);
+    font-weight: 600;
+  }
+
+  .row.dir {
+    color: var(--muted-foreground, #6b7280);
+    cursor: default;
+  }
+
+  .row:disabled {
+    cursor: default;
+  }
+
+  .row-icon {
+    display: grid;
+    place-items: center;
+    flex-shrink: 0;
+    color: var(--muted-foreground, #6b7280);
+  }
+
+  .row.active .row-icon {
+    color: var(--primary, #6366f1);
+  }
+
+  .row-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+</style>

--- a/src/lib/ui/FileExplorer.svelte
+++ b/src/lib/ui/FileExplorer.svelte
@@ -43,13 +43,28 @@
   let loading = $state(false);
   let errorMsg = $state<string | null>(null);
 
+  // User-navigated root override. When set, takes precedence over the active
+  // file's parent dir. Reset to null whenever the active file changes so the
+  // sidebar snaps back to the new file's folder.
+  let manualRoot = $state<string | null>(null);
+
   // Shared expansion + child cache used by every TreeNode.
   const expanded = new SvelteMap<string, boolean>();
   const cache = new SvelteMap<string, DirEntry[]>();
   const loadingSet = new SvelteSet<string>();
 
-  async function refreshRoot(targetPath: string): Promise<void> {
-    if (!targetPath) {
+  const effectiveRoot = $derived(
+    manualRoot ?? (appState.filePath ? parentDir(appState.filePath) : ''),
+  );
+
+  const canGoUp = $derived.by(() => {
+    if (!effectiveRoot) return false;
+    const up = parentDir(effectiveRoot);
+    return up !== effectiveRoot;
+  });
+
+  async function refreshRoot(dir: string): Promise<void> {
+    if (!dir) {
       rootEntries = [];
       rootPath = '';
       errorMsg = null;
@@ -61,26 +76,41 @@
     loading = true;
     errorMsg = null;
     try {
-      const result = await invoke<DirEntry[]>('list_directory', { path: targetPath });
+      const result = await invoke<DirEntry[]>('list_directory', { path: dir });
       rootEntries = result;
-      rootPath = parentDir(targetPath) || targetPath;
-      cache.set(rootPath, result);
+      rootPath = dir;
+      cache.set(dir, result);
     } catch (e) {
       errorMsg = e instanceof Error ? e.message : 'Failed to read directory';
       rootEntries = [];
+      rootPath = dir;
     } finally {
       loading = false;
     }
   }
 
-  // Re-read root when active file's parent dir changes (not when file itself changes inside same dir).
-  let lastRootPath = '';
+  function goUp(): void {
+    if (!canGoUp) return;
+    manualRoot = parentDir(effectiveRoot);
+  }
+
+  // Snap manualRoot back whenever the active file changes.
+  let lastFilePath = appState.filePath;
   $effect(() => {
-    const fp = appState.filePath ?? '';
-    const newRoot = fp ? parentDir(fp) : '';
-    if (newRoot !== lastRootPath) {
-      lastRootPath = newRoot;
-      refreshRoot(fp);
+    const fp = appState.filePath;
+    if (fp !== lastFilePath) {
+      lastFilePath = fp;
+      manualRoot = null;
+    }
+  });
+
+  // Refresh whenever the effective root changes (file change OR manual nav).
+  let lastEffectiveRoot = '';
+  $effect(() => {
+    const root = effectiveRoot;
+    if (root !== lastEffectiveRoot) {
+      lastEffectiveRoot = root;
+      refreshRoot(root);
     }
   });
 
@@ -89,8 +119,8 @@
   );
 
   onMount(() => {
-    if (appState.filePath) {
-      refreshRoot(appState.filePath);
+    if (effectiveRoot) {
+      refreshRoot(effectiveRoot);
     }
   });
 
@@ -158,6 +188,18 @@
 
 <aside class="file-explorer" style="width: {appState.sidebarWidth}px">
   <header class="header">
+    <button
+      type="button"
+      class="icon-btn"
+      title="Go to parent folder"
+      onclick={goUp}
+      disabled={!canGoUp}
+      aria-label="Go to parent folder"
+    >
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <polyline points="15 18 9 12 15 6"></polyline>
+      </svg>
+    </button>
     <span class="header-title" title={rootPath}>
       {rootPath ? basename(rootPath) || rootPath : 'No folder'}
     </span>
@@ -169,7 +211,7 @@
         cache.clear();
         expanded.clear();
         loadingSet.clear();
-        refreshRoot(appState.filePath ?? '');
+        refreshRoot(effectiveRoot);
       }}
       aria-label="Refresh"
     >
@@ -267,9 +309,14 @@
     padding: 0;
   }
 
-  .icon-btn:hover {
+  .icon-btn:hover:not(:disabled) {
     background: var(--accent, rgba(0, 0, 0, 0.06));
     color: var(--foreground, #111);
+  }
+
+  .icon-btn:disabled {
+    opacity: 0.35;
+    cursor: default;
   }
 
   .body {

--- a/src/lib/ui/FileExplorer.svelte
+++ b/src/lib/ui/FileExplorer.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import { onMount } from 'svelte';
   import { invoke } from '@tauri-apps/api/core';
+  import { SvelteMap, SvelteSet } from 'svelte/reactivity';
   import { appState } from '$lib/state/app-state.svelte';
+  import FileTreeNode from './FileTreeNode.svelte';
 
   interface Props {
     onOpenFile: (path: string) => void;
@@ -18,16 +20,9 @@
     'html', 'htm', 'txt', 'md', 'markdown', 'rst', 'log',
   ]);
 
-  let entries = $state<DirEntry[]>([]);
-  let dirPath = $state<string>('');
-  let loading = $state(false);
-  let errorMsg = $state<string | null>(null);
-
   const SEP_RX = /[\\/]/;
 
   function parentDir(path: string): string {
-    const idx = path.search(SEP_RX);
-    if (idx === -1) return '';
     const lastIdx = Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\'));
     return lastIdx > 0 ? path.slice(0, lastIdx) : path;
   }
@@ -43,61 +38,78 @@
     return OPENABLE_EXTS.has(name.slice(dot + 1).toLowerCase());
   }
 
-  async function refresh(targetPath: string): Promise<void> {
+  let rootEntries = $state<DirEntry[]>([]);
+  let rootPath = $state<string>('');
+  let loading = $state(false);
+  let errorMsg = $state<string | null>(null);
+
+  // Shared expansion + child cache used by every TreeNode.
+  const expanded = new SvelteMap<string, boolean>();
+  const cache = new SvelteMap<string, DirEntry[]>();
+  const loadingSet = new SvelteSet<string>();
+
+  async function refreshRoot(targetPath: string): Promise<void> {
     if (!targetPath) {
-      entries = [];
-      dirPath = '';
+      rootEntries = [];
+      rootPath = '';
       errorMsg = null;
+      expanded.clear();
+      cache.clear();
+      loadingSet.clear();
       return;
     }
     loading = true;
     errorMsg = null;
     try {
       const result = await invoke<DirEntry[]>('list_directory', { path: targetPath });
-      entries = result;
-      dirPath = parentDir(targetPath) || targetPath;
+      rootEntries = result;
+      rootPath = parentDir(targetPath) || targetPath;
+      cache.set(rootPath, result);
     } catch (e) {
       errorMsg = e instanceof Error ? e.message : 'Failed to read directory';
-      entries = [];
+      rootEntries = [];
     } finally {
       loading = false;
     }
   }
 
-  // Re-read when active file changes.
+  // Re-read root when active file's parent dir changes (not when file itself changes inside same dir).
+  let lastRootPath = '';
   $effect(() => {
-    refresh(appState.filePath ?? '');
+    const fp = appState.filePath ?? '';
+    const newRoot = fp ? parentDir(fp) : '';
+    if (newRoot !== lastRootPath) {
+      lastRootPath = newRoot;
+      refreshRoot(fp);
+    }
   });
 
-  const visibleEntries = $derived(
-    entries.filter((e) => e.is_dir || isOpenable(e.name)),
+  const visibleRoot = $derived(
+    rootEntries.filter((e) => e.is_dir || isOpenable(e.name)),
   );
-
-  const activeFilename = $derived(
-    appState.filePath ? basename(appState.filePath) : null,
-  );
-
-  function handleClick(entry: DirEntry): void {
-    if (entry.is_dir) return;
-    if (entry.path === appState.filePath) return;
-    onOpenFile(entry.path);
-  }
 
   onMount(() => {
-    refresh(appState.filePath ?? '');
+    if (appState.filePath) {
+      refreshRoot(appState.filePath);
+    }
   });
 </script>
 
 <aside class="file-explorer" style="width: {appState.sidebarWidth}px">
   <header class="header">
-    <span class="header-title" title={dirPath}>
-      {dirPath ? basename(dirPath) || dirPath : 'No folder'}
+    <span class="header-title" title={rootPath}>
+      {rootPath ? basename(rootPath) || rootPath : 'No folder'}
     </span>
     <button
       type="button"
       class="icon-btn"
       title="Refresh"
-      onclick={() => refresh(appState.filePath ?? '')}
+      onclick={() => {
+        cache.clear();
+        expanded.clear();
+        loadingSet.clear();
+        refreshRoot(appState.filePath ?? '');
+      }}
       aria-label="Refresh"
     >
       <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -110,43 +122,25 @@
   <div class="body">
     {#if !appState.filePath}
       <p class="empty">Open a file to see its folder here.</p>
-    {:else if loading && entries.length === 0}
+    {:else if loading && rootEntries.length === 0}
       <p class="empty">Loading…</p>
     {:else if errorMsg}
       <p class="empty error">{errorMsg}</p>
-    {:else if visibleEntries.length === 0}
+    {:else if visibleRoot.length === 0}
       <p class="empty">No openable files in this folder.</p>
     {:else}
-      <ul class="list">
-        {#each visibleEntries as entry (entry.path)}
-          {@const isActive = entry.name === activeFilename}
-          <li>
-            <button
-              type="button"
-              class="row"
-              class:active={isActive}
-              class:dir={entry.is_dir}
-              disabled={entry.is_dir}
-              onclick={() => handleClick(entry)}
-              title={entry.path}
-            >
-              <span class="row-icon" aria-hidden="true">
-                {#if entry.is_dir}
-                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path>
-                  </svg>
-                {:else}
-                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
-                    <polyline points="14 2 14 8 20 8"></polyline>
-                  </svg>
-                {/if}
-              </span>
-              <span class="row-name">{entry.name}</span>
-            </button>
-          </li>
+      <div class="tree">
+        {#each visibleRoot as entry (entry.path)}
+          <FileTreeNode
+            {entry}
+            depth={0}
+            {expanded}
+            {cache}
+            loading={loadingSet}
+            {onOpenFile}
+          />
         {/each}
-      </ul>
+      </div>
     {/if}
   </div>
 </aside>
@@ -171,7 +165,6 @@
     gap: 8px;
     padding: 8px 10px;
     border-bottom: 1px solid var(--border-color, rgba(0, 0, 0, 0.08));
-    background: transparent;
   }
 
   .header-title {
@@ -215,6 +208,10 @@
     display: none;
   }
 
+  .tree {
+    padding: 4px 0;
+  }
+
   .empty {
     padding: 14px 12px;
     color: var(--muted-foreground, #6b7280);
@@ -224,62 +221,5 @@
 
   .empty.error {
     color: #ef4444;
-  }
-
-  .list {
-    list-style: none;
-    margin: 0;
-    padding: 4px 0;
-  }
-
-  .row {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    width: 100%;
-    padding: 5px 12px;
-    border: none;
-    background: transparent;
-    color: inherit;
-    font-size: 13px;
-    text-align: left;
-    cursor: pointer;
-    border-radius: 0;
-  }
-
-  .row:hover:not(:disabled) {
-    background: var(--accent, rgba(0, 0, 0, 0.06));
-  }
-
-  .row.active {
-    background: color-mix(in srgb, var(--primary, #6366f1) 14%, transparent);
-    color: var(--primary, #6366f1);
-    font-weight: 600;
-  }
-
-  .row.dir {
-    color: var(--muted-foreground, #6b7280);
-    cursor: default;
-  }
-
-  .row:disabled {
-    cursor: default;
-  }
-
-  .row-icon {
-    display: grid;
-    place-items: center;
-    flex-shrink: 0;
-    color: var(--muted-foreground, #6b7280);
-  }
-
-  .row.active .row-icon {
-    color: var(--primary, #6366f1);
-  }
-
-  .row-name {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
 </style>

--- a/src/lib/ui/FileExplorer.svelte
+++ b/src/lib/ui/FileExplorer.svelte
@@ -94,20 +94,31 @@
     }
   });
 
-  async function createDocument(): Promise<void> {
-    if (!rootPath) return;
+  async function createDocumentIn(dir: string): Promise<void> {
+    if (!dir) return;
     try {
-      const result = await invoke<{ path: string }>('create_document', {
-        dir: rootPath,
-      });
+      const result = await invoke<{ path: string }>('create_document', { dir });
       onOpenFile(result.path);
-      // The new file lives in the same root; the file-change effect won't
-      // refresh because parentDir is unchanged. Force a re-read so it appears.
-      cache.delete(rootPath);
-      await refreshRoot(result.path);
+      if (dir === rootPath) {
+        cache.delete(rootPath);
+        await refreshRoot(result.path);
+      } else {
+        // Refresh just this folder's cached children + ensure it's expanded.
+        try {
+          const children = await invoke<DirEntry[]>('list_directory', { path: dir });
+          cache.set(dir, children);
+          expanded.set(dir, true);
+        } catch {
+          // Ignore - the parent dir reload below will still surface the file.
+        }
+      }
     } catch (e) {
       errorMsg = e instanceof Error ? e.message : 'Failed to create document';
     }
+  }
+
+  function createDocumentInRoot(): Promise<void> {
+    return createDocumentIn(rootPath);
   }
 </script>
 
@@ -116,19 +127,6 @@
     <span class="header-title" title={rootPath}>
       {rootPath ? basename(rootPath) || rootPath : 'No folder'}
     </span>
-    <button
-      type="button"
-      class="icon-btn"
-      title="New document in this folder"
-      onclick={createDocument}
-      disabled={!rootPath}
-      aria-label="New document"
-    >
-      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <line x1="12" y1="5" x2="12" y2="19"></line>
-        <line x1="5" y1="12" x2="19" y2="12"></line>
-      </svg>
-    </button>
     <button
       type="button"
       class="icon-btn"
@@ -167,8 +165,21 @@
             {cache}
             loading={loadingSet}
             {onOpenFile}
+            onCreateInFolder={createDocumentIn}
           />
         {/each}
+        <button
+          type="button"
+          class="root-add-row"
+          onclick={createDocumentInRoot}
+          title="Add document to {basename(rootPath) || rootPath}"
+        >
+          <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="12" y1="5" x2="12" y2="19"></line>
+            <line x1="5" y1="12" x2="19" y2="12"></line>
+          </svg>
+          <span>New document</span>
+        </button>
       </div>
     {/if}
   </div>
@@ -239,6 +250,26 @@
 
   .tree {
     padding: 4px 0;
+  }
+
+  .root-add-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    padding: 5px 12px 5px 26px;
+    border: none;
+    background: transparent;
+    color: var(--muted-foreground, #6b7280);
+    font-size: 12px;
+    text-align: left;
+    cursor: pointer;
+    margin-top: 2px;
+  }
+
+  .root-add-row:hover {
+    background: var(--accent, rgba(0, 0, 0, 0.06));
+    color: var(--foreground, #111);
   }
 
   .empty {

--- a/src/lib/ui/FileExplorer.svelte
+++ b/src/lib/ui/FileExplorer.svelte
@@ -93,6 +93,22 @@
       refreshRoot(appState.filePath);
     }
   });
+
+  async function createDocument(): Promise<void> {
+    if (!rootPath) return;
+    try {
+      const result = await invoke<{ path: string }>('create_document', {
+        dir: rootPath,
+      });
+      onOpenFile(result.path);
+      // The new file lives in the same root; the file-change effect won't
+      // refresh because parentDir is unchanged. Force a re-read so it appears.
+      cache.delete(rootPath);
+      await refreshRoot(result.path);
+    } catch (e) {
+      errorMsg = e instanceof Error ? e.message : 'Failed to create document';
+    }
+  }
 </script>
 
 <aside class="file-explorer" style="width: {appState.sidebarWidth}px">
@@ -100,6 +116,19 @@
     <span class="header-title" title={rootPath}>
       {rootPath ? basename(rootPath) || rootPath : 'No folder'}
     </span>
+    <button
+      type="button"
+      class="icon-btn"
+      title="New document in this folder"
+      onclick={createDocument}
+      disabled={!rootPath}
+      aria-label="New document"
+    >
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <line x1="12" y1="5" x2="12" y2="19"></line>
+        <line x1="5" y1="12" x2="19" y2="12"></line>
+      </svg>
+    </button>
     <button
       type="button"
       class="icon-btn"

--- a/src/lib/ui/FileTreeNode.svelte
+++ b/src/lib/ui/FileTreeNode.svelte
@@ -16,9 +16,18 @@
     cache: Map<string, DirEntry[]>;
     loading: Set<string>;
     onOpenFile: (path: string) => void;
+    onCreateInFolder: (folderPath: string) => void;
   }
 
-  const { entry, depth, expanded, cache, loading, onOpenFile }: Props = $props();
+  const {
+    entry,
+    depth,
+    expanded,
+    cache,
+    loading,
+    onOpenFile,
+    onCreateInFolder,
+  }: Props = $props();
 
   const OPENABLE_EXTS = new Set([
     'html', 'htm', 'txt', 'md', 'markdown', 'rst', 'log',
@@ -105,9 +114,7 @@
   {#if isLoading && !children}
     <div class="loading" style="padding-left: {8 + (depth + 1) * 14 + 12}px">Loading…</div>
   {:else if children}
-    {#if children.length === 0}
-      <div class="empty-child" style="padding-left: {8 + (depth + 1) * 14 + 12}px">empty</div>
-    {:else}
+    {#if children.length > 0}
       {#each children as child (child.path)}
         <Self
           entry={child}
@@ -116,9 +123,23 @@
           {cache}
           {loading}
           {onOpenFile}
+          {onCreateInFolder}
         />
       {/each}
     {/if}
+    <button
+      type="button"
+      class="add-row"
+      style="padding-left: {8 + (depth + 1) * 14 + 12 + 6}px"
+      onclick={() => onCreateInFolder(entry.path)}
+      title="Add document to {entry.name}"
+    >
+      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+        <line x1="12" y1="5" x2="12" y2="19"></line>
+        <line x1="5" y1="12" x2="19" y2="12"></line>
+      </svg>
+      <span>New document</span>
+    </button>
   {/if}
 {/if}
 
@@ -190,11 +211,29 @@
     white-space: nowrap;
   }
 
-  .loading,
-  .empty-child {
+  .loading {
     font-size: 12px;
     color: var(--muted-foreground, #6b7280);
     padding-top: 2px;
     padding-bottom: 4px;
+  }
+
+  .add-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    padding: 3px 12px;
+    border: none;
+    background: transparent;
+    color: var(--muted-foreground, #6b7280);
+    font-size: 12px;
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .add-row:hover {
+    background: var(--accent, rgba(0, 0, 0, 0.06));
+    color: var(--foreground, #111);
   }
 </style>

--- a/src/lib/ui/FileTreeNode.svelte
+++ b/src/lib/ui/FileTreeNode.svelte
@@ -17,6 +17,7 @@
     loading: Set<string>;
     onOpenFile: (path: string) => void;
     onCreateInFolder: (folderPath: string) => void;
+    onMoveFile: (src: string, dstDir: string) => void;
   }
 
   const {
@@ -27,7 +28,39 @@
     loading,
     onOpenFile,
     onCreateInFolder,
+    onMoveFile,
   }: Props = $props();
+
+  let dragOver = $state(false);
+
+  function handleDragStart(e: DragEvent): void {
+    if (entry.is_dir) return;
+    if (!e.dataTransfer) return;
+    e.dataTransfer.setData('application/x-ante-path', entry.path);
+    e.dataTransfer.effectAllowed = 'move';
+  }
+
+  function handleDragOver(e: DragEvent): void {
+    if (!entry.is_dir) return;
+    if (!e.dataTransfer?.types.includes('application/x-ante-path')) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    dragOver = true;
+  }
+
+  function handleDragLeave(): void {
+    dragOver = false;
+  }
+
+  function handleDrop(e: DragEvent): void {
+    if (!entry.is_dir) return;
+    const src = e.dataTransfer?.getData('application/x-ante-path');
+    dragOver = false;
+    if (!src) return;
+    e.preventDefault();
+    if (src === entry.path) return;
+    onMoveFile(src, entry.path);
+  }
 
   const OPENABLE_EXTS = new Set([
     'html', 'htm', 'txt', 'md', 'markdown', 'rst', 'log',
@@ -82,8 +115,14 @@
   class="row"
   class:active={isActive}
   class:dir={entry.is_dir}
+  class:drop-target={dragOver}
   style="padding-left: {8 + depth * 14}px"
+  draggable={!entry.is_dir}
   onclick={handleClick}
+  ondragstart={handleDragStart}
+  ondragover={handleDragOver}
+  ondragleave={handleDragLeave}
+  ondrop={handleDrop}
   title={entry.path}
 >
   {#if entry.is_dir}
@@ -124,6 +163,7 @@
           {loading}
           {onOpenFile}
           {onCreateInFolder}
+          {onMoveFile}
         />
       {/each}
     {/if}
@@ -171,6 +211,12 @@
 
   .row.dir {
     color: var(--foreground, #111);
+  }
+
+  .row.drop-target {
+    background: color-mix(in srgb, var(--primary, #6366f1) 18%, transparent);
+    outline: 1px dashed var(--primary, #6366f1);
+    outline-offset: -2px;
   }
 
   .chevron {

--- a/src/lib/ui/FileTreeNode.svelte
+++ b/src/lib/ui/FileTreeNode.svelte
@@ -1,0 +1,200 @@
+<script lang="ts">
+  import { invoke } from '@tauri-apps/api/core';
+  import Self from './FileTreeNode.svelte';
+  import { appState } from '$lib/state/app-state.svelte';
+
+  interface DirEntry {
+    name: string;
+    path: string;
+    is_dir: boolean;
+  }
+
+  interface Props {
+    entry: DirEntry;
+    depth: number;
+    expanded: Map<string, boolean>;
+    cache: Map<string, DirEntry[]>;
+    loading: Set<string>;
+    onOpenFile: (path: string) => void;
+  }
+
+  const { entry, depth, expanded, cache, loading, onOpenFile }: Props = $props();
+
+  const OPENABLE_EXTS = new Set([
+    'html', 'htm', 'txt', 'md', 'markdown', 'rst', 'log',
+  ]);
+
+  function isOpenable(name: string): boolean {
+    const dot = name.lastIndexOf('.');
+    if (dot === -1) return false;
+    return OPENABLE_EXTS.has(name.slice(dot + 1).toLowerCase());
+  }
+
+  const isExpanded = $derived(expanded.get(entry.path) ?? false);
+  const isLoading = $derived(loading.has(entry.path));
+  const isActive = $derived(!entry.is_dir && entry.path === appState.filePath);
+
+  const children = $derived.by(() => {
+    const raw = cache.get(entry.path);
+    if (!raw) return null;
+    return raw.filter((c) => c.is_dir || isOpenable(c.name));
+  });
+
+  async function toggle(): Promise<void> {
+    if (!entry.is_dir) return;
+    const willExpand = !isExpanded;
+    expanded.set(entry.path, willExpand);
+    if (willExpand && !cache.has(entry.path) && !loading.has(entry.path)) {
+      loading.add(entry.path);
+      try {
+        const result = await invoke<DirEntry[]>('list_directory', {
+          path: entry.path,
+        });
+        cache.set(entry.path, result);
+      } catch {
+        cache.set(entry.path, []);
+      } finally {
+        loading.delete(entry.path);
+      }
+    }
+  }
+
+  function handleClick(): void {
+    if (entry.is_dir) {
+      toggle();
+    } else if (entry.path !== appState.filePath) {
+      onOpenFile(entry.path);
+    }
+  }
+</script>
+
+<button
+  type="button"
+  class="row"
+  class:active={isActive}
+  class:dir={entry.is_dir}
+  style="padding-left: {8 + depth * 14}px"
+  onclick={handleClick}
+  title={entry.path}
+>
+  {#if entry.is_dir}
+    <span class="chevron" class:open={isExpanded} aria-hidden="true">
+      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+        <polyline points="9 18 15 12 9 6"></polyline>
+      </svg>
+    </span>
+  {:else}
+    <span class="chevron-spacer" aria-hidden="true"></span>
+  {/if}
+  <span class="row-icon" aria-hidden="true">
+    {#if entry.is_dir}
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path>
+      </svg>
+    {:else}
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+        <polyline points="14 2 14 8 20 8"></polyline>
+      </svg>
+    {/if}
+  </span>
+  <span class="row-name">{entry.name}</span>
+</button>
+
+{#if entry.is_dir && isExpanded}
+  {#if isLoading && !children}
+    <div class="loading" style="padding-left: {8 + (depth + 1) * 14 + 12}px">Loading…</div>
+  {:else if children}
+    {#if children.length === 0}
+      <div class="empty-child" style="padding-left: {8 + (depth + 1) * 14 + 12}px">empty</div>
+    {:else}
+      {#each children as child (child.path)}
+        <Self
+          entry={child}
+          depth={depth + 1}
+          {expanded}
+          {cache}
+          {loading}
+          {onOpenFile}
+        />
+      {/each}
+    {/if}
+  {/if}
+{/if}
+
+<style>
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    padding: 4px 12px 4px 8px;
+    border: none;
+    background: transparent;
+    color: inherit;
+    font-size: 13px;
+    text-align: left;
+    cursor: pointer;
+    border-radius: 0;
+  }
+
+  .row:hover {
+    background: var(--accent, rgba(0, 0, 0, 0.06));
+  }
+
+  .row.active {
+    background: color-mix(in srgb, var(--primary, #6366f1) 14%, transparent);
+    color: var(--primary, #6366f1);
+    font-weight: 600;
+  }
+
+  .row.dir {
+    color: var(--foreground, #111);
+  }
+
+  .chevron {
+    display: grid;
+    place-items: center;
+    width: 12px;
+    height: 12px;
+    color: var(--muted-foreground, #6b7280);
+    transition: transform 120ms ease;
+    flex-shrink: 0;
+  }
+
+  .chevron.open {
+    transform: rotate(90deg);
+  }
+
+  .chevron-spacer {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    flex-shrink: 0;
+  }
+
+  .row-icon {
+    display: grid;
+    place-items: center;
+    flex-shrink: 0;
+    color: var(--muted-foreground, #6b7280);
+  }
+
+  .row.active .row-icon {
+    color: var(--primary, #6366f1);
+  }
+
+  .row-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .loading,
+  .empty-child {
+    font-size: 12px;
+    color: var(--muted-foreground, #6b7280);
+    padding-top: 2px;
+    padding-bottom: 4px;
+  }
+</style>

--- a/src/lib/ui/Toolbar.svelte
+++ b/src/lib/ui/Toolbar.svelte
@@ -10,10 +10,11 @@
     onOpen?: () => void;
     onSave?: () => void;
     onSaveAs?: () => void;
+    onToggleSidebar?: () => void;
     onToggleAi?: () => void;
   }
 
-  let { editor, onNew, onOpen, onSave, onSaveAs, onToggleAi }: Props = $props();
+  let { editor, onNew, onOpen, onSave, onSaveAs, onToggleSidebar, onToggleAi }: Props = $props();
 
   function setPageSize(e: Event): void {
     appState.pageSize = (e.target as HTMLSelectElement).value as PageSize;
@@ -144,6 +145,23 @@
 </script>
 
 <div class="toolbar" role="toolbar" aria-label="Formatting toolbar">
+  <!-- Sidebar toggle -->
+  <div class="toolbar-group">
+    <button
+      class="toolbar-btn"
+      class:active={appState.sidebarOpen}
+      title="Toggle file explorer (Cmd+B)"
+      onclick={() => onToggleSidebar?.()}
+      aria-label="Toggle file explorer"
+    >
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+        <line x1="9" y1="3" x2="9" y2="21"></line>
+      </svg>
+    </button>
+  </div>
+  <div class="toolbar-divider"></div>
+
   <!-- File group -->
   <div class="toolbar-group">
     <button

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,9 +8,11 @@
   import StatusBar from '$lib/ui/StatusBar.svelte';
   import SettingsDialog from '$lib/ui/SettingsDialog.svelte';
   import AiSetupBanner from '$lib/ui/AiSetupBanner.svelte';
+  import FileExplorer from '$lib/ui/FileExplorer.svelte';
   import { appState } from '$lib/state/app-state.svelte';
   import {
     openFile,
+    openPath,
     saveFile,
     saveFileAs,
     newFile,
@@ -80,6 +82,13 @@
     updateCounts();
   }
 
+  async function handleOpenFromSidebar(path: string): Promise<void> {
+    await openPath(path, getBridge());
+    editor = editorComponent?.getEditor();
+    toolbar?.bumpTick();
+    updateCounts();
+  }
+
   async function handleSave(): Promise<void> {
     await saveFile(getBridge());
   }
@@ -141,6 +150,13 @@
       if (e.metaKey && e.key === ',') {
         e.preventDefault();
         appState.settingsOpen = true;
+        return;
+      }
+
+      // Cmd+B: Toggle file explorer sidebar
+      if (e.metaKey && !e.shiftKey && (e.key === 'b' || e.key === 'B')) {
+        e.preventDefault();
+        appState.sidebarOpen = !appState.sidebarOpen;
         return;
       }
     };
@@ -228,18 +244,24 @@
     onOpen={handleOpen}
     onSave={handleSave}
     onSaveAs={() => saveFileAs(getBridge())}
+    onToggleSidebar={() => (appState.sidebarOpen = !appState.sidebarOpen)}
     onToggleAi={toggleAi}
   />
-  <PageStack {contentHeight} {pageBreaks}>
-    <EditorComponent
-      bind:this={editorComponent}
-      content=""
-      onContentChange={handleContentChange}
-      onSelectionUpdate={handleSelectionUpdate}
-      onContentHeightChange={handleContentHeightChange}
-      onPageBreaksChange={handlePageBreaksChange}
-    />
-  </PageStack>
+  <div class="app-body">
+    {#if appState.sidebarOpen}
+      <FileExplorer onOpenFile={handleOpenFromSidebar} />
+    {/if}
+    <PageStack {contentHeight} {pageBreaks}>
+      <EditorComponent
+        bind:this={editorComponent}
+        content=""
+        onContentChange={handleContentChange}
+        onSelectionUpdate={handleSelectionUpdate}
+        onContentHeightChange={handleContentHeightChange}
+        onPageBreaksChange={handlePageBreaksChange}
+      />
+    </PageStack>
+  </div>
   <StatusBar />
   <SettingsDialog />
   <AiSetupBanner />
@@ -251,6 +273,14 @@
     height: 100vh;
     display: flex;
     flex-direction: column;
+    overflow: hidden;
+  }
+
+  .app-body {
+    flex: 1;
+    display: flex;
+    flex-direction: row;
+    min-height: 0;
     overflow: hidden;
   }
 </style>


### PR DESCRIPTION
## Summary

Closes #11. Adds a left sidebar mirroring the parent folder of the active document, with a recursive tree, lazy-loaded children, inline 'new document' rows, drag-and-drop file moves, and parent-folder navigation.

## What's in

- **Backend (Rust)**: new commands `list_directory`, `read_file`, `create_document`, `move_path`. All capped/sandboxed (500-entry list cap, 10MB file cap, no overwrite on move).
- **Sidebar UI**: `FileExplorer.svelte` + recursive `FileTreeNode.svelte`. Folders expand on click via chevron, children fetched once and cached in a SvelteMap.
- **Inline 'New document' rows** at the end of every expanded folder + at the bottom of the root tree, so users see exactly where the file lands.
- **Drag-and-drop**: drag a file row, drop on any folder row to move. Drop target gets a dashed outline. Custom MIME (`application/x-ante-path`) so we don't catch native OS drops. Active doc's path follows the move.
- **Up arrow** in the sidebar header navigates to the parent folder. Resets back to the active file's folder whenever a different file is opened.
- **Toolbar toggle** + `Cmd+B` keybind to show/hide the sidebar. Active file row highlighted in primary colour.

## Test plan

- [ ] Open a file - sidebar shows that file's folder, file highlighted.
- [ ] Click a sibling - it loads, dirty-prompt fires when applicable.
- [ ] Click a folder chevron - children load and cache; collapse/expand stays instant.
- [ ] '+ New document' row at root and inside an expanded folder both work; new file appears + opens.
- [ ] Drag a file onto a folder - moves it; active doc still saves to the new path.
- [ ] Up arrow goes to parent dir; opening a file resets to that file's folder.
- [ ] Cmd+B toggles the sidebar; tooltip on the toolbar button matches.