### PR TITLE
feat: welcome screen with recent files

### DIFF
--- a/src/lib/state/file-ops.ts
+++ b/src/lib/state/file-ops.ts
@@ -3,6 +3,7 @@ import { message } from '@tauri-apps/plugin-dialog';
 import type { FilePayload, SaveAsResult, AnteError } from '$lib/types';
 import { ERROR_MESSAGES } from '$lib/types';
 import { appState } from './app-state.svelte';
+import { recentFiles } from './recent-files.svelte';
 
 /** Snapshot of the document at last save, used for dirty detection. */
 let savedSnapshot = '';
@@ -118,6 +119,7 @@ export async function openFile(bridge: EditorBridge): Promise<void> {
     // directly from their input handlers.
     savedSnapshot = stripped;
     appState.isDirty = false;
+    recentFiles.add(result.path);
 
     bridge.setHTML(stripped);
   } catch (err) {
@@ -148,6 +150,7 @@ export async function openPath(path: string, bridge: EditorBridge): Promise<void
     appState.footerText = footer;
     savedSnapshot = stripped;
     appState.isDirty = false;
+    recentFiles.add(result.path);
 
     bridge.setHTML(stripped);
   } catch (err) {
@@ -203,6 +206,7 @@ export async function saveFileAs(bridge: EditorBridge): Promise<void> {
     appState.filePath = result.path;
     savedSnapshot = editorHtml;
     appState.isDirty = false;
+    recentFiles.add(result.path);
   } catch (err) {
     await showError(err);
   }

--- a/src/lib/state/recent-files.svelte.ts
+++ b/src/lib/state/recent-files.svelte.ts
@@ -1,0 +1,73 @@
+const STORAGE_KEY = 'ante.recentFiles';
+const MAX_RECENTS = 10;
+
+export interface RecentFile {
+  path: string;
+  openedAt: number;
+}
+
+function safeRead(): RecentFile[] {
+  if (typeof localStorage === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter(
+        (x): x is RecentFile =>
+          typeof x === 'object' &&
+          x !== null &&
+          typeof (x as RecentFile).path === 'string' &&
+          typeof (x as RecentFile).openedAt === 'number',
+      )
+      .slice(0, MAX_RECENTS);
+  } catch {
+    return [];
+  }
+}
+
+function safeWrite(list: RecentFile[]): void {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+  } catch {
+    /* quota or unavailable; ignore */
+  }
+}
+
+let recents = $state<RecentFile[]>(safeRead());
+
+export const recentFiles = {
+  get list(): RecentFile[] {
+    return recents;
+  },
+  add(path: string): void {
+    const next = [{ path, openedAt: Date.now() }, ...recents.filter((r) => r.path !== path)].slice(
+      0,
+      MAX_RECENTS,
+    );
+    recents = next;
+    safeWrite(next);
+  },
+  remove(path: string): void {
+    const next = recents.filter((r) => r.path !== path);
+    recents = next;
+    safeWrite(next);
+  },
+  clear(): void {
+    recents = [];
+    safeWrite([]);
+  },
+};
+
+export function filenameFromPath(path: string): string {
+  const parts = path.split(/[\\/]/);
+  return parts[parts.length - 1] || path;
+}
+
+export function dirFromPath(path: string): string {
+  const parts = path.split(/[\\/]/);
+  parts.pop();
+  return parts.join('/') || '';
+}

--- a/src/lib/ui/WelcomeScreen.svelte
+++ b/src/lib/ui/WelcomeScreen.svelte
@@ -1,0 +1,213 @@
+<script lang="ts">
+  import { recentFiles, filenameFromPath, dirFromPath } from '$lib/state/recent-files.svelte';
+  import { appState } from '$lib/state/app-state.svelte';
+
+  interface Props {
+    onNew: () => void;
+    onOpen: () => void;
+    onOpenPath: (path: string) => void;
+  }
+
+  let { onNew, onOpen, onOpenPath }: Props = $props();
+
+  const isMac = typeof navigator !== 'undefined' && /mac/i.test(navigator.platform);
+  const mod = isMac ? '\u2318' : 'Ctrl';
+
+  function handleRemove(event: MouseEvent, path: string): void {
+    event.stopPropagation();
+    recentFiles.remove(path);
+  }
+</script>
+
+<div class="welcome" class:dark={appState.resolvedTheme === 'dark'}>
+  <div class="welcome-inner">
+    <h1 class="title">ante</h1>
+    <p class="tagline">A calm place to write.</p>
+
+    <section class="column">
+      <h2 class="section-label">Start</h2>
+      <button class="row action" onclick={onNew}>
+        <span class="label">New file</span>
+        <span class="shortcut">{mod} N</span>
+      </button>
+      <button class="row action" onclick={onOpen}>
+        <span class="label">Open file...</span>
+        <span class="shortcut">{mod} O</span>
+      </button>
+    </section>
+
+    <section class="column">
+      <h2 class="section-label">Recent</h2>
+      {#if recentFiles.list.length === 0}
+        <p class="empty">No recent files.</p>
+      {:else}
+        {#each recentFiles.list as item (item.path)}
+          <button class="row recent" onclick={() => onOpenPath(item.path)} title={item.path}>
+            <span class="label">{filenameFromPath(item.path)}</span>
+            <span class="dir">{dirFromPath(item.path)}</span>
+            <span
+              class="remove"
+              role="button"
+              tabindex="0"
+              aria-label="Remove from recents"
+              title="Remove from recents"
+              onclick={(e) => handleRemove(e, item.path)}
+              onkeydown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  recentFiles.remove(item.path);
+                }
+              }}
+            >×</span>
+          </button>
+        {/each}
+      {/if}
+    </section>
+  </div>
+</div>
+
+<style>
+  .welcome {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--canvas-bg, #f6f5f2);
+    color: var(--fg, #1a1a1a);
+    overflow: auto;
+    padding: 48px 24px;
+  }
+
+  .welcome.dark {
+    background: var(--canvas-bg, #141414);
+    color: var(--fg, #e6e6e6);
+  }
+
+  .welcome-inner {
+    width: 100%;
+    max-width: 520px;
+    display: flex;
+    flex-direction: column;
+    gap: 28px;
+  }
+
+  .title {
+    font-family: 'Inter Variable', system-ui, sans-serif;
+    font-size: 44px;
+    font-weight: 300;
+    letter-spacing: -0.02em;
+    margin: 0;
+    line-height: 1;
+  }
+
+  .tagline {
+    margin: -16px 0 0;
+    font-size: 14px;
+    opacity: 0.55;
+  }
+
+  .column {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .section-label {
+    font-size: 11px;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    opacity: 0.5;
+    margin: 0 0 6px;
+  }
+
+  .row {
+    display: flex;
+    align-items: baseline;
+    gap: 10px;
+    padding: 8px 10px;
+    border-radius: 6px;
+    background: transparent;
+    border: none;
+    color: inherit;
+    text-align: left;
+    font: inherit;
+    cursor: pointer;
+    width: 100%;
+    transition: background-color 0.12s ease;
+  }
+
+  .row:hover,
+  .row:focus-visible {
+    background: color-mix(in srgb, currentColor 8%, transparent);
+    outline: none;
+  }
+
+  .row.action .label {
+    font-size: 15px;
+  }
+
+  .row.recent {
+    position: relative;
+  }
+
+  .label {
+    font-size: 14px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex-shrink: 0;
+    max-width: 240px;
+  }
+
+  .dir {
+    font-size: 12px;
+    opacity: 0.5;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex: 1;
+    direction: rtl;
+    text-align: left;
+  }
+
+  .shortcut {
+    margin-left: auto;
+    font-size: 12px;
+    opacity: 0.45;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0.04em;
+  }
+
+  .empty {
+    font-size: 13px;
+    opacity: 0.5;
+    margin: 4px 10px;
+  }
+
+  .remove {
+    margin-left: 8px;
+    opacity: 0;
+    width: 18px;
+    height: 18px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 3px;
+    font-size: 14px;
+    line-height: 1;
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: opacity 0.12s ease, background-color 0.12s ease;
+  }
+
+  .row.recent:hover .remove,
+  .row.recent:focus-within .remove {
+    opacity: 0.6;
+  }
+
+  .remove:hover {
+    opacity: 1 !important;
+    background: color-mix(in srgb, currentColor 12%, transparent);
+  }
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, tick } from 'svelte';
   import type { Editor } from '@tiptap/core';
   import { invoke } from '@tauri-apps/api/core';
   import EditorComponent from '$lib/editor/Editor.svelte';
@@ -9,6 +9,7 @@
   import SettingsDialog from '$lib/ui/SettingsDialog.svelte';
   import AiSetupBanner from '$lib/ui/AiSetupBanner.svelte';
   import FileExplorer from '$lib/ui/FileExplorer.svelte';
+  import WelcomeScreen from '$lib/ui/WelcomeScreen.svelte';
   import { appState } from '$lib/state/app-state.svelte';
   import {
     openFile,
@@ -21,11 +22,12 @@
     type EditorBridge,
   } from '$lib/state/file-ops';
 
-  let editorComponent: EditorComponent;
+  let editorComponent = $state<EditorComponent | undefined>(undefined);
   let toolbar: Toolbar;
   let editor = $state<Editor | undefined>(undefined);
   let contentHeight = $state(0);
   let pageBreaks = $state<number[]>([]);
+  let showWelcome = $state(true);
 
   function handleContentHeightChange(height: number): void {
     contentHeight = height;
@@ -70,20 +72,42 @@
   }
 
   async function handleNew(): Promise<void> {
-    await newFile(getBridge());
+    const wasWelcome = showWelcome;
+    showWelcome = false;
+    await tick();
+    const created = await newFile(getBridge());
+    if (!created && wasWelcome) {
+      showWelcome = true;
+      return;
+    }
+    editor = editorComponent?.getEditor();
+    toolbar?.bumpTick();
     updateCounts();
   }
 
   async function handleOpen(): Promise<void> {
+    const wasWelcome = showWelcome;
+    showWelcome = false;
+    await tick();
     await openFile(getBridge());
-    // After opening, update editor reference and counts
+    if (!appState.filePath && wasWelcome) {
+      showWelcome = true;
+      return;
+    }
     editor = editorComponent?.getEditor();
     toolbar?.bumpTick();
     updateCounts();
   }
 
   async function handleOpenFromSidebar(path: string): Promise<void> {
+    const wasWelcome = showWelcome;
+    showWelcome = false;
+    await tick();
     await openPath(path, getBridge());
+    if (!appState.filePath && wasWelcome) {
+      showWelcome = true;
+      return;
+    }
     editor = editorComponent?.getEditor();
     toolbar?.bumpTick();
     updateCounts();
@@ -251,16 +275,24 @@
     {#if appState.sidebarOpen}
       <FileExplorer onOpenFile={handleOpenFromSidebar} />
     {/if}
-    <PageStack {contentHeight} {pageBreaks}>
-      <EditorComponent
-        bind:this={editorComponent}
-        content=""
-        onContentChange={handleContentChange}
-        onSelectionUpdate={handleSelectionUpdate}
-        onContentHeightChange={handleContentHeightChange}
-        onPageBreaksChange={handlePageBreaksChange}
+    {#if showWelcome}
+      <WelcomeScreen
+        onNew={handleNew}
+        onOpen={handleOpen}
+        onOpenPath={handleOpenFromSidebar}
       />
-    </PageStack>
+    {:else}
+      <PageStack {contentHeight} {pageBreaks}>
+        <EditorComponent
+          bind:this={editorComponent}
+          content=""
+          onContentChange={handleContentChange}
+          onSelectionUpdate={handleSelectionUpdate}
+          onContentHeightChange={handleContentHeightChange}
+          onPageBreaksChange={handlePageBreaksChange}
+        />
+      </PageStack>
+    {/if}
   </div>
   <StatusBar />
   <SettingsDialog />


### PR DESCRIPTION
## Summary
- New Cursor-style welcome screen shown at launch when no file is open. Clean and minimal: title, "Start" actions (New file / Open file) with keyboard shortcuts, and "Recent" list
- Recent files persisted to localStorage (max 10), auto-updated on open and save-as, per-item remove on hover
- Welcome hides on user action; if the action is cancelled, it restores rather than leaving a blank editor

## Test plan
- [ ] App launches to welcome screen
- [ ] "New file" creates empty document and hides welcome
- [ ] "Open file..." opens native dialog; on cancel, welcome remains
- [ ] Opening a file adds it to Recent; reopening surfaces it at the top
- [ ] Remove (×) button deletes an entry without opening it
- [ ] Sidebar "Open" (Cmd+B) also adds to recents
- [ ] `pnpm check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)