### PR TITLE
chore: release v0.2.0 (trigger-speed presets + bump)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ante",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
 
 [[package]]
 name = "ante"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ante"
-version = "0.1.0"
+version = "0.2.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/src/ai.rs
+++ b/src-tauri/src/ai.rs
@@ -63,6 +63,10 @@ const DEFAULT_MAX_TOKENS: u32 = 80;
 const DEFAULT_TRIGGER_SPEED: &str = "balanced";
 const TEMPERATURE: f32 = 0.3;
 
+fn is_valid_trigger_speed(s: &str) -> bool {
+    matches!(s, "eager" | "quick" | "balanced")
+}
+
 /// Returns a boxed provider client for the given provider.
 pub fn client_for(provider: Provider) -> Box<dyn ProviderClient> {
     match provider {
@@ -393,7 +397,7 @@ fn get_config(app: &AppHandle) -> ResolvedConfig {
             let trigger_speed = store
                 .get(KEY_TRIGGER_SPEED)
                 .and_then(|v| v.as_str().map(|s| s.to_string()))
-                .filter(|s| matches!(s.as_str(), "eager" | "balanced" | "relaxed"))
+                .filter(|s| is_valid_trigger_speed(s.as_str()))
                 .unwrap_or_else(|| DEFAULT_TRIGGER_SPEED.to_string());
 
             let (model, base_url, max_tokens) = read_provider_slot(&store, active);
@@ -698,7 +702,7 @@ pub fn load_ai_config(app: AppHandle) -> AiConfigMeta {
         store
             .get(KEY_TRIGGER_SPEED)
             .and_then(|v| v.as_str().map(|s| s.to_string()))
-            .filter(|s| matches!(s.as_str(), "eager" | "balanced" | "relaxed"))
+            .filter(|s| is_valid_trigger_speed(s.as_str()))
             .unwrap_or_else(|| DEFAULT_TRIGGER_SPEED.to_string())
     } else {
         DEFAULT_TRIGGER_SPEED.to_string()
@@ -755,7 +759,7 @@ pub fn save_ai_config(
     }
 
     if let Some(speed) = payload.trigger_speed.as_deref() {
-        if matches!(speed, "eager" | "balanced" | "relaxed") {
+        if is_valid_trigger_speed(speed) {
             store.set(KEY_TRIGGER_SPEED, serde_json::Value::String(speed.to_string()));
         }
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ante",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "identifier": "com.ante",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/lib/state/app-state.svelte.ts
+++ b/src/lib/state/app-state.svelte.ts
@@ -57,22 +57,32 @@ let sidebarOpen = $state<boolean>(false);
 let sidebarWidth = $state<number>(240);
 
 /** Trigger speed for ghost autocomplete. Controls debounce + cooldown. */
-export type AiTriggerSpeed = 'eager' | 'balanced' | 'relaxed';
+export type AiTriggerSpeed = 'eager' | 'quick' | 'balanced';
+export const AI_TRIGGER_SPEEDS: readonly AiTriggerSpeed[] = [
+  'eager',
+  'quick',
+  'balanced',
+] as const;
 let aiTriggerSpeed = $state<AiTriggerSpeed>('balanced');
 
 /** Max tokens per suggestion. Controls suggestion length. */
 let aiMaxTokens = $state<number>(80);
 
+// 300ms is the lower bound - anything faster hits provider rate limits.
 const TRIGGER_SPEED_DEBOUNCE: Record<AiTriggerSpeed, number> = {
   eager: 300,
+  quick: 500,
   balanced: 800,
-  relaxed: 1500,
 };
 const TRIGGER_SPEED_COOLDOWN: Record<AiTriggerSpeed, number> = {
   eager: 800,
+  quick: 1400,
   balanced: 2000,
-  relaxed: 3500,
 };
+
+export function isAiTriggerSpeed(v: unknown): v is AiTriggerSpeed {
+  return typeof v === 'string' && (AI_TRIGGER_SPEEDS as readonly string[]).includes(v);
+}
 const aiDebounceMs: number = $derived(TRIGGER_SPEED_DEBOUNCE[aiTriggerSpeed]);
 const aiCooldownMs: number = $derived(TRIGGER_SPEED_COOLDOWN[aiTriggerSpeed]);
 

--- a/src/lib/ui/SettingsDialog.svelte
+++ b/src/lib/ui/SettingsDialog.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { invoke } from '@tauri-apps/api/core';
   import { openUrl } from '@tauri-apps/plugin-opener';
-  import { appState, type AiTriggerSpeed } from '$lib/state/app-state.svelte';
+  import { appState, type AiTriggerSpeed, isAiTriggerSpeed } from '$lib/state/app-state.svelte';
   import { Button, buttonVariants } from '$lib/components/ui/button/index.js';
   import * as Dialog from '$lib/components/ui/dialog/index.js';
   import { Input } from '$lib/components/ui/input/index.js';
@@ -243,12 +243,7 @@
       }
 
       suggestionLength = tokensToLength(providerForms[activeProvider].maxTokens);
-      triggerSpeed =
-        meta.trigger_speed === 'eager' ||
-        meta.trigger_speed === 'balanced' ||
-        meta.trigger_speed === 'relaxed'
-          ? meta.trigger_speed
-          : 'balanced';
+      triggerSpeed = isAiTriggerSpeed(meta.trigger_speed) ? meta.trigger_speed : 'balanced';
     } catch {
       // No store yet (dev browser).
     }
@@ -519,8 +514,8 @@
           <Label for="trigger-speed">Trigger speed</Label>
           <select id="trigger-speed" class={selectClass} bind:value={triggerSpeed}>
             <option value="eager">Eager (300ms)</option>
+            <option value="quick">Quick (500ms)</option>
             <option value="balanced">Balanced (800ms)</option>
-            <option value="relaxed">Relaxed (1.5s)</option>
           </select>
         </div>
       </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,7 +10,7 @@
   import AiSetupBanner from '$lib/ui/AiSetupBanner.svelte';
   import FileExplorer from '$lib/ui/FileExplorer.svelte';
   import WelcomeScreen from '$lib/ui/WelcomeScreen.svelte';
-  import { appState } from '$lib/state/app-state.svelte';
+  import { appState, isAiTriggerSpeed } from '$lib/state/app-state.svelte';
   import {
     openFile,
     openPath,
@@ -225,7 +225,7 @@
         if (activeSlot) {
           appState.aiMaxTokens = activeSlot.max_tokens;
         }
-        if (meta.trigger_speed === 'eager' || meta.trigger_speed === 'balanced' || meta.trigger_speed === 'relaxed') {
+        if (isAiTriggerSpeed(meta.trigger_speed)) {
           appState.aiTriggerSpeed = meta.trigger_speed;
         }
       } catch {


### PR DESCRIPTION
## Summary
- Add quick trigger-speed presets (eager / balanced / relaxed)
- Bump version 0.1.0 -> 0.2.0 across package.json, Cargo.toml, tauri.conf.json

## Test plan
- [x] pnpm check (0 errors, 0 warnings)
- [x] cargo check --all-targets
- [x] cargo test --lib (21/21)
- [ ] Post-merge: tag v0.2.0 triggers release workflow; verify draft release artifacts