### PR TITLE
feat(#18): DOCX import + export (Word interop)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "@tiptap/pm": "^3.22.3",
     "@tiptap/starter-kit": "^3.22.3",
     "clsx": "^2.1.1",
+    "docx": "^9.6.1",
+    "mammoth": "^1.12.0",
     "shadcn-svelte": "^1.2.7",
     "tailwind-merge": "^3.5.0",
     "tailwind-variants": "^3.2.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,12 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      docx:
+        specifier: ^9.6.1
+        version: 9.6.1
+      mammoth:
+        specifier: ^1.12.0
+        version: 1.12.0
       shadcn-svelte:
         specifier: ^1.2.7
         version: 1.2.7(svelte@5.55.4)
@@ -74,22 +80,22 @@ importers:
         version: 1.8.0(svelte@5.55.4)
       '@sveltejs/adapter-static':
         specifier: ^3.0.10
-        version: 3.0.10(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(typescript@5.6.3)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)))
+        version: 3.0.10(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(typescript@5.6.3)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)))
       '@sveltejs/kit':
         specifier: ^2.9.0
-        version: 2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(typescript@5.6.3)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0))
+        version: 2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(typescript@5.6.3)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.0
-        version: 5.1.1(svelte@5.55.4)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0))
+        version: 5.1.1(svelte@5.55.4)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0))
       '@tailwindcss/vite':
         specifier: ^4.2.2
-        version: 4.2.2(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0))
+        version: 4.2.2(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0))
       '@tauri-apps/cli':
         specifier: ^2
         version: 2.10.1
       bits-ui:
         specifier: ^2.16.3
-        version: 2.17.3(@internationalized/date@3.12.1)(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(typescript@5.6.3)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)
+        version: 2.17.3(@internationalized/date@3.12.1)(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(typescript@5.6.3)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)
       svelte:
         specifier: ^5.0.0
         version: 5.55.4
@@ -107,7 +113,7 @@ importers:
         version: 5.6.3
       vite:
         specifier: ^6.0.3
-        version: 6.4.2(jiti@2.6.1)(lightningcss@1.32.0)
+        version: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)
 
 packages:
 
@@ -823,13 +829,23 @@ packages:
   '@types/mdurl@2.0.0':
     resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@xmldom/xmldom@0.8.13':
+    resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
+    engines: {node: '>=10.0.0'}
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -842,12 +858,18 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   bits-ui@2.17.3:
     resolution: {integrity: sha512-Bef41uY9U2jaBJHPhcPvmBNkGec5Wx2z6eioDsTmsaR2vH4QoaOcPi75gzCG3+/2TNr6v/qBwzgWNPYCxNtrEA==}
     engines: {node: '>=20'}
     peerDependencies:
       '@internationalized/date': ^3.8.1
       svelte: ^5.33.0
+
+  bluebird@3.4.7:
+    resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -864,6 +886,9 @@ packages:
   cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
     engines: {node: '>= 0.6'}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
@@ -891,6 +916,16 @@ packages:
 
   devalue@5.7.1:
     resolution: {integrity: sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==}
+
+  dingbat-to-unicode@1.0.1:
+    resolution: {integrity: sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==}
+
+  docx@9.6.1:
+    resolution: {integrity: sha512-ZJja9/KBUuFC109sCMzovoq2GR2wCG/AuxivjA+OHj/q0TEgJIm3S7yrlUxIy3B+bV8YDj/BiHfWyrRFmyWpDQ==}
+    engines: {node: '>=10'}
+
+  duck@0.1.12:
+    resolution: {integrity: sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==}
 
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
@@ -937,19 +972,37 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  hash.js@1.1.7:
+    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
+
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1030,6 +1083,9 @@ packages:
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
+  lop@0.4.2:
+    resolution: {integrity: sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==}
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -1037,12 +1093,20 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  mammoth@1.12.0:
+    resolution: {integrity: sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
+
   markdown-it@14.1.1:
     resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
     hasBin: true
 
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
+
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -1060,11 +1124,26 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@5.1.9:
+    resolution: {integrity: sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
 
+  option@0.2.4:
+    resolution: {integrity: sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==}
+
   orderedmap@2.1.1:
     resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
+
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1076,6 +1155,9 @@ packages:
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
+
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
   prosemirror-changeset@2.4.1:
     resolution: {integrity: sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==}
@@ -1139,6 +1221,9 @@ packages:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
     engines: {node: '>=6'}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
@@ -1164,8 +1249,18 @@ packages:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
+  sax@1.6.0:
+    resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
+    engines: {node: '>=11.0.0'}
+
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
+
+  setimmediate@1.0.5:
+    resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
   shadcn-svelte@1.2.7:
     resolution: {integrity: sha512-mWuQk4H4gtV+J2wJQ7nEPKNnB/v86AALFryZU0SSM7ChHmJJMZ1kH+qIuxYKrXm9vOOOcSWHRsWzPDB71DnjYA==}
@@ -1180,6 +1275,12 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
@@ -1247,6 +1348,15 @@ packages:
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
+  underscore@1.13.8:
+    resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
+
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
   vite@6.4.2:
     resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -1297,6 +1407,17 @@ packages:
 
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
+  xml-js@1.6.11:
+    resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
+    hasBin: true
+
+  xml@1.0.1:
+    resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
+
+  xmlbuilder@10.1.1:
+    resolution: {integrity: sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==}
+    engines: {node: '>=4.0'}
 
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
@@ -1506,15 +1627,15 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(typescript@5.6.3)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)))':
+  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(typescript@5.6.3)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)))':
     dependencies:
-      '@sveltejs/kit': 2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(typescript@5.6.3)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0))
+      '@sveltejs/kit': 2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(typescript@5.6.3)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0))
 
-  '@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(typescript@5.6.3)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0))':
+  '@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(typescript@5.6.3)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.4)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.4)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0))
       '@types/cookie': 0.6.0
       acorn: 8.16.0
       cookie: 0.6.0
@@ -1526,29 +1647,29 @@ snapshots:
       set-cookie-parser: 3.1.0
       sirv: 3.0.2
       svelte: 5.55.4
-      vite: 6.4.2(jiti@2.6.1)(lightningcss@1.32.0)
+      vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)
     optionalDependencies:
       typescript: 5.6.3
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.4)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0))
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.4)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0))
       debug: 4.4.3
       svelte: 5.55.4
-      vite: 6.4.2(jiti@2.6.1)(lightningcss@1.32.0)
+      vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0))':
+  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0))
       debug: 4.4.3
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.21
       svelte: 5.55.4
-      vite: 6.4.2(jiti@2.6.1)(lightningcss@1.32.0)
-      vitefu: 1.1.3(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0))
+      vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)
+      vitefu: 1.1.3(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -1617,12 +1738,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
 
-  '@tailwindcss/vite@4.2.2(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0))':
+  '@tailwindcss/vite@4.2.2(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: 6.4.2(jiti@2.6.1)(lightningcss@1.32.0)
+      vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)
 
   '@tauri-apps/api@2.10.1': {}
 
@@ -1866,9 +1987,19 @@ snapshots:
 
   '@types/mdurl@2.0.0': {}
 
+  '@types/node@25.6.0':
+    dependencies:
+      undici-types: 7.19.2
+
   '@types/trusted-types@2.0.7': {}
 
+  '@xmldom/xmldom@0.8.13': {}
+
   acorn@8.16.0: {}
+
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
 
@@ -1876,18 +2007,22 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  bits-ui@2.17.3(@internationalized/date@3.12.1)(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(typescript@5.6.3)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4):
+  base64-js@1.5.1: {}
+
+  bits-ui@2.17.3(@internationalized/date@3.12.1)(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(typescript@5.6.3)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4):
     dependencies:
       '@floating-ui/core': 1.7.5
       '@floating-ui/dom': 1.7.6
       '@internationalized/date': 3.12.1
       esm-env: 1.2.2
-      runed: 0.35.1(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(typescript@5.6.3)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)
+      runed: 0.35.1(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(typescript@5.6.3)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)
       svelte: 5.55.4
-      svelte-toolbelt: 0.10.6(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(typescript@5.6.3)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)
+      svelte-toolbelt: 0.10.6(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(typescript@5.6.3)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)
       tabbable: 6.4.0
     transitivePeerDependencies:
       - '@sveltejs/kit'
+
+  bluebird@3.4.7: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -1898,6 +2033,8 @@ snapshots:
   commander@14.0.3: {}
 
   cookie@0.6.0: {}
+
+  core-util-is@1.0.3: {}
 
   crelt@1.0.6: {}
 
@@ -1912,6 +2049,21 @@ snapshots:
   detect-libc@2.1.2: {}
 
   devalue@5.7.1: {}
+
+  dingbat-to-unicode@1.0.1: {}
+
+  docx@9.6.1:
+    dependencies:
+      '@types/node': 25.6.0
+      hash.js: 1.1.7
+      jszip: 3.10.1
+      nanoid: 5.1.9
+      xml: 1.0.1
+      xml-js: 1.6.11
+
+  duck@0.1.12:
+    dependencies:
+      underscore: 1.13.8
 
   enhanced-resolve@5.20.1:
     dependencies:
@@ -1966,15 +2118,37 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  hash.js@1.1.7:
+    dependencies:
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+
+  immediate@3.0.6: {}
+
+  inherits@2.0.4: {}
+
   inline-style-parser@0.2.7: {}
 
   is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
 
+  isarray@1.0.0: {}
+
   jiti@2.6.1: {}
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   kleur@4.1.5: {}
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -2033,11 +2207,30 @@ snapshots:
 
   locate-character@3.0.0: {}
 
+  lop@0.4.2:
+    dependencies:
+      duck: 0.1.12
+      option: 0.2.4
+      underscore: 1.13.8
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  mammoth@1.12.0:
+    dependencies:
+      '@xmldom/xmldom': 0.8.13
+      argparse: 1.0.10
+      base64-js: 1.5.1
+      bluebird: 3.4.7
+      dingbat-to-unicode: 1.0.1
+      jszip: 3.10.1
+      lop: 0.4.2
+      path-is-absolute: 1.0.1
+      underscore: 1.13.8
+      xmlbuilder: 10.1.1
 
   markdown-it@14.1.1:
     dependencies:
@@ -2050,6 +2243,8 @@ snapshots:
 
   mdurl@2.0.0: {}
 
+  minimalistic-assert@1.0.1: {}
+
   mri@1.2.0: {}
 
   mrmime@2.0.1: {}
@@ -2058,9 +2253,17 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@5.1.9: {}
+
   node-fetch-native@1.6.7: {}
 
+  option@0.2.4: {}
+
   orderedmap@2.1.1: {}
+
+  pako@1.0.11: {}
+
+  path-is-absolute@1.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -2071,6 +2274,8 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  process-nextick-args@2.0.1: {}
 
   prosemirror-changeset@2.4.1:
     dependencies:
@@ -2177,6 +2382,16 @@ snapshots:
 
   punycode.js@2.3.1: {}
 
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
   readdirp@4.1.2: {}
 
   rollup@4.60.1:
@@ -2212,20 +2427,26 @@ snapshots:
 
   rope-sequence@1.3.4: {}
 
-  runed@0.35.1(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(typescript@5.6.3)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4):
+  runed@0.35.1(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(typescript@5.6.3)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4):
     dependencies:
       dequal: 2.0.3
       esm-env: 1.2.2
       lz-string: 1.5.0
       svelte: 5.55.4
     optionalDependencies:
-      '@sveltejs/kit': 2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(typescript@5.6.3)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0))
+      '@sveltejs/kit': 2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(typescript@5.6.3)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0))
 
   sade@1.8.1:
     dependencies:
       mri: 1.2.0
 
+  safe-buffer@5.1.2: {}
+
+  sax@1.6.0: {}
+
   set-cookie-parser@3.1.0: {}
+
+  setimmediate@1.0.5: {}
 
   shadcn-svelte@1.2.7(svelte@5.55.4):
     dependencies:
@@ -2243,6 +2464,12 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  sprintf-js@1.0.3: {}
+
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
   style-to-object@1.0.14:
     dependencies:
       inline-style-parser: 0.2.7
@@ -2259,10 +2486,10 @@ snapshots:
     transitivePeerDependencies:
       - picomatch
 
-  svelte-toolbelt@0.10.6(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(typescript@5.6.3)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4):
+  svelte-toolbelt@0.10.6(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(typescript@5.6.3)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4):
     dependencies:
       clsx: 2.1.1
-      runed: 0.35.1(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(typescript@5.6.3)(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)
+      runed: 0.35.1(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(typescript@5.6.3)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)
       style-to-object: 1.0.14
       svelte: 5.55.4
     transitivePeerDependencies:
@@ -2318,7 +2545,13 @@ snapshots:
 
   uc.micro@2.1.0: {}
 
-  vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0):
+  underscore@1.13.8: {}
+
+  undici-types@7.19.2: {}
+
+  util-deprecate@1.0.2: {}
+
+  vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -2327,14 +2560,23 @@ snapshots:
       rollup: 4.60.1
       tinyglobby: 0.2.16
     optionalDependencies:
+      '@types/node': 25.6.0
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
 
-  vitefu@1.1.3(vite@6.4.2(jiti@2.6.1)(lightningcss@1.32.0)):
+  vitefu@1.1.3(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)):
     optionalDependencies:
-      vite: 6.4.2(jiti@2.6.1)(lightningcss@1.32.0)
+      vite: 6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)
 
   w3c-keyname@2.2.8: {}
+
+  xml-js@1.6.11:
+    dependencies:
+      sax: 1.6.0
+
+  xml@1.0.1: {}
+
+  xmlbuilder@10.1.1: {}
 
   zimmerframe@1.1.4: {}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -9,10 +9,15 @@ const MAX_FILE_SIZE: u64 = 10 * 1024 * 1024;
 /// Number of bytes to scan for null bytes (binary detection).
 const BINARY_CHECK_LEN: usize = 8192;
 
+/// Discriminated payload returned by `open_file` / `read_file` so the
+/// frontend can branch on file kind without re-sniffing the path.
 #[derive(Serialize)]
-pub struct FilePayload {
-    pub path: String,
-    pub contents: String,
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum OpenedFile {
+    /// Plain-text file (HTML, MD, TXT, ...). Validated UTF-8.
+    Text { path: String, contents: String },
+    /// Binary `.docx` file. `bytes_b64` is the file contents base64-encoded.
+    Docx { path: String, bytes_b64: String },
 }
 
 #[derive(Serialize)]
@@ -155,10 +160,10 @@ pub async fn move_path(src: String, dst_dir: String) -> Result<SaveAsResult, Ant
 }
 
 /// Reads a file at the given path. Used by the sidebar to open a file the user
-/// clicked, bypassing the native picker dialog. Same size + UTF-8 + binary
-/// guards as `open_file`.
+/// clicked, bypassing the native picker dialog. Routes `.docx` to the binary
+/// path; everything else is read as UTF-8 text with the usual guards.
 #[tauri::command]
-pub async fn read_file(path: String) -> Result<FilePayload, AnteError> {
+pub async fn read_file(path: String) -> Result<OpenedFile, AnteError> {
     let metadata = tokio::fs::metadata(&path).await?;
     if metadata.len() > MAX_FILE_SIZE {
         return Err(AnteError::FileTooLarge(format!(
@@ -168,6 +173,12 @@ pub async fn read_file(path: String) -> Result<FilePayload, AnteError> {
         )));
     }
     let buf = tokio::fs::read(&path).await?;
+
+    if is_docx_path(&path) {
+        let bytes_b64 = base64::engine::general_purpose::STANDARD.encode(&buf);
+        return Ok(OpenedFile::Docx { path, bytes_b64 });
+    }
+
     if is_binary(&buf) {
         return Err(AnteError::BinaryFile(format!(
             "File appears to be binary: {}",
@@ -175,7 +186,12 @@ pub async fn read_file(path: String) -> Result<FilePayload, AnteError> {
         )));
     }
     let contents = validate_utf8(buf, &path)?;
-    Ok(FilePayload { path, contents })
+    Ok(OpenedFile::Text { path, contents })
+}
+
+/// Returns true if the path ends with `.docx` (case-insensitive).
+fn is_docx_path(path: &str) -> bool {
+    path.to_lowercase().ends_with(".docx")
 }
 
 /// Returns true if the buffer contains null bytes in the first BINARY_CHECK_LEN bytes.
@@ -247,13 +263,16 @@ fn mime_from_path(path: &str) -> &'static str {
     }
 }
 
-/// Opens a native file dialog and reads the selected file.
+/// Opens a native file dialog and reads the selected file. Routes `.docx`
+/// through the binary path; everything else is read as UTF-8 text.
 #[tauri::command]
-pub async fn open_file(app: tauri::AppHandle) -> Result<FilePayload, AnteError> {
+pub async fn open_file(app: tauri::AppHandle) -> Result<OpenedFile, AnteError> {
     let file_path = app
         .dialog()
         .file()
+        .add_filter("All Supported", &["html", "htm", "docx", "txt", "md", "text", "markdown", "rst", "log"])
         .add_filter("HTML Files", &["html", "htm"])
+        .add_filter("Word Documents", &["docx"])
         .add_filter("Text Files", &["txt", "md", "text", "markdown", "rst", "log"])
         .add_filter("All Files", &["*"])
         .blocking_pick_file();
@@ -275,6 +294,14 @@ pub async fn open_file(app: tauri::AppHandle) -> Result<FilePayload, AnteError> 
 
     let buf = tokio::fs::read(&file_path).await?;
 
+    if is_docx_path(&file_path) {
+        let bytes_b64 = base64::engine::general_purpose::STANDARD.encode(&buf);
+        return Ok(OpenedFile::Docx {
+            path: file_path,
+            bytes_b64,
+        });
+    }
+
     if is_binary(&buf) {
         return Err(AnteError::BinaryFile(format!(
             "File appears to be binary: {}",
@@ -284,7 +311,7 @@ pub async fn open_file(app: tauri::AppHandle) -> Result<FilePayload, AnteError> 
 
     let contents = validate_utf8(buf, &file_path)?;
 
-    Ok(FilePayload {
+    Ok(OpenedFile::Text {
         path: file_path,
         contents,
     })
@@ -322,18 +349,53 @@ pub async fn save_file_as(
     Ok(SaveAsResult { path: file_path })
 }
 
+/// Opens a native save dialog filtered to `.docx` and writes binary bytes
+/// (decoded from base64) to the chosen path. Used for Word document export.
+#[tauri::command]
+pub async fn save_docx_as(
+    app: tauri::AppHandle,
+    bytes_b64: String,
+    suggested_name: Option<String>,
+) -> Result<SaveAsResult, AnteError> {
+    let mut dialog = app
+        .dialog()
+        .file()
+        .add_filter("Word Document", &["docx"]);
+
+    if let Some(name) = suggested_name {
+        dialog = dialog.set_file_name(&name);
+    }
+
+    let file_path = match dialog.blocking_save_file() {
+        Some(p) => p.to_string(),
+        None => return Err(AnteError::DialogCancelled),
+    };
+
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(bytes_b64.as_bytes())
+        .map_err(|e| AnteError::Io(format!("invalid base64 payload: {}", e)))?;
+
+    atomic_write_bytes(&file_path, &bytes).await?;
+
+    Ok(SaveAsResult { path: file_path })
+}
+
 /// Writes contents to a file atomically: write to temp file in the same directory,
 /// then rename. Falls back to direct overwrite if rename fails.
 async fn atomic_write(path: &str, contents: &str) -> Result<(), AnteError> {
+    atomic_write_bytes(path, contents.as_bytes()).await
+}
+
+/// Binary-safe version of `atomic_write`. Used for `.docx` export.
+async fn atomic_write_bytes(path: &str, bytes: &[u8]) -> Result<(), AnteError> {
     let tmp_path = format!("{}.tmp~", path);
 
-    tokio::fs::write(&tmp_path, contents.as_bytes()).await?;
+    tokio::fs::write(&tmp_path, bytes).await?;
 
     match tokio::fs::rename(&tmp_path, path).await {
         Ok(()) => Ok(()),
         Err(_rename_err) => {
-            // Fallback: direct overwrite. Remove temp file best-effort.
-            let result = tokio::fs::write(path, contents.as_bytes()).await;
+            let result = tokio::fs::write(path, bytes).await;
             let _ = tokio::fs::remove_file(&tmp_path).await;
             result.map_err(AnteError::from)
         }
@@ -423,5 +485,43 @@ mod tests {
         let result = validate_utf8(buf, "empty.txt");
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "");
+    }
+
+    #[test]
+    fn test_is_docx_path_recognizes_extension() {
+        assert!(is_docx_path("document.docx"));
+        assert!(is_docx_path("/path/to/Report.DOCX"));
+        assert!(is_docx_path("My File.Docx"));
+    }
+
+    #[test]
+    fn test_is_docx_path_rejects_non_docx() {
+        assert!(!is_docx_path("document.html"));
+        assert!(!is_docx_path("document.doc"));
+        assert!(!is_docx_path("docx"));
+        assert!(!is_docx_path("docx.html"));
+        assert!(!is_docx_path(""));
+    }
+
+    #[test]
+    fn test_opened_file_text_serialization_tag() {
+        let payload = OpenedFile::Text {
+            path: "/tmp/x.html".into(),
+            contents: "<p>hi</p>".into(),
+        };
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(json.contains("\"kind\":\"text\""));
+        assert!(json.contains("\"contents\":\"<p>hi</p>\""));
+    }
+
+    #[test]
+    fn test_opened_file_docx_serialization_tag() {
+        let payload = OpenedFile::Docx {
+            path: "/tmp/x.docx".into(),
+            bytes_b64: "UEsDBBQAAAA".into(),
+        };
+        let json = serde_json::to_string(&payload).unwrap();
+        assert!(json.contains("\"kind\":\"docx\""));
+        assert!(json.contains("\"bytes_b64\":\"UEsDBBQAAAA\""));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,6 +17,7 @@ pub fn run() {
             commands::move_path,
             commands::save_file,
             commands::save_file_as,
+            commands::save_docx_as,
             commands::pick_image,
             ai::stream_completion,
             ai::cancel_completion,

--- a/src/lib/io/docx.ts
+++ b/src/lib/io/docx.ts
@@ -1,0 +1,292 @@
+/**
+ * DOCX <-> HTML interop.
+ *
+ * Import path: mammoth converts a `.docx` byte buffer to HTML that TipTap
+ * can ingest via `setContent`.
+ *
+ * Export path: a focused walker turns the HTML the editor produces into a
+ * `docx.Document` tree, then `Packer` serialises it to bytes. The walker
+ * covers the MVP surface from issue #18: paragraphs, headings, marks,
+ * lists, hyperlinks, alignment. Out-of-scope features (tables, images,
+ * footnotes) are dropped silently to avoid blocking export.
+ */
+
+import mammoth from 'mammoth';
+import {
+  Document,
+  Packer,
+  Paragraph,
+  TextRun,
+  HeadingLevel,
+  AlignmentType,
+  ExternalHyperlink,
+  LevelFormat,
+} from 'docx';
+
+const NUMBERED_REF = 'ante-numbered';
+
+const HEADING_LEVELS: Record<string, (typeof HeadingLevel)[keyof typeof HeadingLevel]> = {
+  H1: HeadingLevel.HEADING_1,
+  H2: HeadingLevel.HEADING_2,
+  H3: HeadingLevel.HEADING_3,
+  H4: HeadingLevel.HEADING_4,
+  H5: HeadingLevel.HEADING_5,
+  H6: HeadingLevel.HEADING_6,
+};
+
+const ALIGNMENT: Record<string, (typeof AlignmentType)[keyof typeof AlignmentType]> = {
+  left: AlignmentType.LEFT,
+  center: AlignmentType.CENTER,
+  right: AlignmentType.RIGHT,
+  justify: AlignmentType.JUSTIFIED,
+};
+
+export interface ImportResult {
+  html: string;
+  warnings: string[];
+}
+
+/** Decode base64 to Uint8Array. */
+function base64ToUint8Array(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+/** Encode Uint8Array as base64. Uses chunked conversion to stay safe on big files. */
+function uint8ArrayToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
+  }
+  return btoa(binary);
+}
+
+/** Convert .docx bytes (base64) to HTML via mammoth. */
+export async function docxBytesToHtml(bytesB64: string): Promise<ImportResult> {
+  const bytes = base64ToUint8Array(bytesB64);
+  // mammoth wants an ArrayBuffer; copy into a fresh one to avoid SharedArrayBuffer typing issues.
+  const ab = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+  const result = await mammoth.convertToHtml({ arrayBuffer: ab as ArrayBuffer });
+  return {
+    html: result.value,
+    warnings: result.messages.map((m) => m.message),
+  };
+}
+
+/** Convert TipTap HTML to a .docx file (returned as base64). */
+export async function htmlToDocxBytes(html: string): Promise<string> {
+  const doc = buildDocument(html);
+  const buffer = await Packer.toBuffer(doc);
+  return uint8ArrayToBase64(new Uint8Array(buffer));
+}
+
+interface RunStyle {
+  bold?: boolean;
+  italics?: boolean;
+  underline?: { type: 'single' };
+  strike?: boolean;
+  color?: string;
+  font?: string;
+  size?: number;
+  link?: string;
+}
+
+function buildDocument(html: string): Document {
+  const dom = new DOMParser().parseFromString(`<!doctype html><body>${html}</body>`, 'text/html');
+  const body = dom.body;
+  const children: Paragraph[] = [];
+  for (const node of Array.from(body.childNodes)) {
+    walkBlock(node, children, {});
+  }
+  if (children.length === 0) children.push(new Paragraph(''));
+
+  return new Document({
+    numbering: {
+      config: [
+        {
+          reference: NUMBERED_REF,
+          levels: [
+            {
+              level: 0,
+              format: LevelFormat.DECIMAL,
+              text: '%1.',
+              alignment: AlignmentType.LEFT,
+            },
+          ],
+        },
+      ],
+    },
+    sections: [{ properties: {}, children }],
+  });
+}
+
+interface BlockContext {
+  list?: 'bullet' | 'numbered';
+}
+
+function walkBlock(node: Node, out: Paragraph[], ctx: BlockContext): void {
+  if (node.nodeType === Node.TEXT_NODE) {
+    const text = node.textContent?.trim();
+    if (text) out.push(paragraphFromInline([textRun(text, {})], {}));
+    return;
+  }
+  if (node.nodeType !== Node.ELEMENT_NODE) return;
+  const el = node as HTMLElement;
+  const tag = el.tagName;
+
+  if (tag === 'P' || tag === 'DIV') {
+    out.push(paragraphFromInline(collectInline(el, {}), { alignment: alignmentFor(el), list: ctx.list }));
+    return;
+  }
+  if (HEADING_LEVELS[tag]) {
+    out.push(
+      paragraphFromInline(collectInline(el, {}), {
+        heading: HEADING_LEVELS[tag],
+        alignment: alignmentFor(el),
+      }),
+    );
+    return;
+  }
+  if (tag === 'BLOCKQUOTE') {
+    for (const child of Array.from(el.childNodes)) walkBlock(child, out, ctx);
+    return;
+  }
+  if (tag === 'UL') {
+    for (const li of Array.from(el.children)) {
+      if (li.tagName === 'LI') walkBlock(li, out, { list: 'bullet' });
+    }
+    return;
+  }
+  if (tag === 'OL') {
+    for (const li of Array.from(el.children)) {
+      if (li.tagName === 'LI') walkBlock(li, out, { list: 'numbered' });
+    }
+    return;
+  }
+  if (tag === 'LI') {
+    out.push(paragraphFromInline(collectInline(el, {}), { list: ctx.list }));
+    return;
+  }
+  if (tag === 'BR') {
+    out.push(new Paragraph(''));
+    return;
+  }
+
+  // Unknown element - recurse to recover any text inside it.
+  for (const child of Array.from(el.childNodes)) walkBlock(child, out, ctx);
+}
+
+function alignmentFor(el: HTMLElement): (typeof AlignmentType)[keyof typeof AlignmentType] | undefined {
+  const raw = (el.style.textAlign || el.getAttribute('align') || '').toLowerCase();
+  return ALIGNMENT[raw];
+}
+
+interface ParagraphOpts {
+  heading?: (typeof HeadingLevel)[keyof typeof HeadingLevel];
+  alignment?: (typeof AlignmentType)[keyof typeof AlignmentType];
+  list?: 'bullet' | 'numbered';
+}
+
+function paragraphFromInline(
+  runs: (TextRun | ExternalHyperlink)[],
+  opts: ParagraphOpts,
+): Paragraph {
+  return new Paragraph({
+    children: runs,
+    ...(opts.heading ? { heading: opts.heading } : {}),
+    ...(opts.alignment ? { alignment: opts.alignment } : {}),
+    ...(opts.list === 'bullet' ? { bullet: { level: 0 } } : {}),
+    ...(opts.list === 'numbered'
+      ? { numbering: { reference: NUMBERED_REF, level: 0 } }
+      : {}),
+  });
+}
+
+function collectInline(el: Element, parentStyle: RunStyle): (TextRun | ExternalHyperlink)[] {
+  const runs: (TextRun | ExternalHyperlink)[] = [];
+  for (const child of Array.from(el.childNodes)) {
+    runs.push(...collectInlineNode(child, parentStyle));
+  }
+  return runs;
+}
+
+function collectInlineNode(node: Node, parentStyle: RunStyle): (TextRun | ExternalHyperlink)[] {
+  if (node.nodeType === Node.TEXT_NODE) {
+    const text = node.textContent ?? '';
+    if (!text) return [];
+    return [textRun(text, parentStyle)];
+  }
+  if (node.nodeType !== Node.ELEMENT_NODE) return [];
+  const el = node as HTMLElement;
+  const tag = el.tagName;
+
+  if (tag === 'BR') return [textRun('\n', parentStyle)];
+
+  if (tag === 'A') {
+    const href = el.getAttribute('href') ?? '';
+    const inner = collectInline(el, { ...parentStyle, link: href });
+    if (!href) return inner;
+    // Wrap the inner runs in an ExternalHyperlink. ExternalHyperlink only
+    // accepts TextRun children, so unwrap any nested hyperlinks.
+    const flatRuns: TextRun[] = inner.flatMap((r) => (r instanceof TextRun ? [r] : []));
+    return [new ExternalHyperlink({ link: href, children: flatRuns })];
+  }
+
+  const style: RunStyle = { ...parentStyle };
+  if (tag === 'STRONG' || tag === 'B') style.bold = true;
+  if (tag === 'EM' || tag === 'I') style.italics = true;
+  if (tag === 'U') style.underline = { type: 'single' };
+  if (tag === 'S' || tag === 'STRIKE' || tag === 'DEL') style.strike = true;
+  if (tag === 'SPAN' || tag === 'FONT') {
+    const fam = el.style.fontFamily;
+    if (fam) style.font = fam.replace(/^['"]|['"]$/g, '');
+    const sizeRaw = el.style.fontSize;
+    if (sizeRaw && sizeRaw.endsWith('px')) {
+      const px = parseInt(sizeRaw, 10);
+      // docx wants size in half-points; px -> pt at 96dpi is px * 0.75; half-points = pt * 2.
+      if (!isNaN(px)) style.size = Math.round(px * 1.5);
+    }
+    const color = el.style.color;
+    if (color) style.color = normalizeColor(color);
+  }
+
+  return collectInline(el, style);
+}
+
+function textRun(text: string, style: RunStyle): TextRun {
+  return new TextRun({
+    text,
+    bold: style.bold,
+    italics: style.italics,
+    underline: style.underline,
+    strike: style.strike,
+    color: style.color,
+    font: style.font,
+    size: style.size,
+  });
+}
+
+/** Normalize CSS color values to a 6-digit hex without leading `#`. */
+function normalizeColor(raw: string): string | undefined {
+  const trimmed = raw.trim();
+  if (trimmed.startsWith('#')) {
+    const hex = trimmed.slice(1);
+    if (/^[0-9a-fA-F]{6}$/.test(hex)) return hex.toUpperCase();
+    if (/^[0-9a-fA-F]{3}$/.test(hex)) {
+      return hex.split('').map((c) => c + c).join('').toUpperCase();
+    }
+    return undefined;
+  }
+  const m = trimmed.match(/^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/i);
+  if (m) {
+    const [, r, g, b] = m;
+    return [r, g, b]
+      .map((n) => Math.min(255, parseInt(n, 10)).toString(16).padStart(2, '0'))
+      .join('')
+      .toUpperCase();
+  }
+  return undefined;
+}

--- a/src/lib/state/file-ops.ts
+++ b/src/lib/state/file-ops.ts
@@ -1,9 +1,10 @@
 import { invoke } from '@tauri-apps/api/core';
 import { message } from '@tauri-apps/plugin-dialog';
-import type { FilePayload, SaveAsResult, AnteError } from '$lib/types';
+import type { OpenedFile, SaveAsResult, AnteError } from '$lib/types';
 import { ERROR_MESSAGES } from '$lib/types';
 import { appState } from './app-state.svelte';
 import { recentFiles } from './recent-files.svelte';
+import { docxBytesToHtml, htmlToDocxBytes } from '$lib/io/docx';
 
 /** Snapshot of the document at last save, used for dirty detection. */
 let savedSnapshot = '';
@@ -106,22 +107,13 @@ export interface EditorBridge {
 
 /**
  * Open a file via native dialog. Replaces the editor content on success.
+ * Routes `.docx` through mammoth; everything else through the existing
+ * HTML/text path.
  */
 export async function openFile(bridge: EditorBridge): Promise<void> {
   try {
-    const result = await invoke<FilePayload>('open_file');
-    const { header, footer, stripped } = parseHeaderFooter(result.contents);
-
-    appState.filePath = result.path;
-    appState.headerText = header;
-    appState.footerText = footer;
-    // Snapshot tracks editor HTML only; header/footer edits flip isDirty
-    // directly from their input handlers.
-    savedSnapshot = stripped;
-    appState.isDirty = false;
-    recentFiles.add(result.path);
-
-    bridge.setHTML(stripped);
+    const result = await invoke<OpenedFile>('open_file');
+    await applyOpenedFile(result, bridge);
   } catch (err) {
     await showError(err);
   }
@@ -142,20 +134,49 @@ export async function openPath(path: string, bridge: EditorBridge): Promise<void
   }
 
   try {
-    const result = await invoke<FilePayload>('read_file', { path });
-    const { header, footer, stripped } = parseHeaderFooter(result.contents);
-
-    appState.filePath = result.path;
-    appState.headerText = header;
-    appState.footerText = footer;
-    savedSnapshot = stripped;
-    appState.isDirty = false;
-    recentFiles.add(result.path);
-
-    bridge.setHTML(stripped);
+    const result = await invoke<OpenedFile>('read_file', { path });
+    await applyOpenedFile(result, bridge);
   } catch (err) {
     await showError(err);
   }
+}
+
+/**
+ * Apply an OpenedFile payload to the editor, branching on kind.
+ * - text: existing header/footer extraction + setHTML
+ * - docx: mammoth-converted HTML, no header/footer (DOCX has its own model)
+ */
+async function applyOpenedFile(file: OpenedFile, bridge: EditorBridge): Promise<void> {
+  if (file.kind === 'docx') {
+    const { html, warnings } = await docxBytesToHtml(file.bytes_b64);
+    appState.filePath = file.path;
+    appState.headerText = '';
+    appState.footerText = '';
+    savedSnapshot = html;
+    appState.isDirty = false;
+    recentFiles.add(file.path);
+    bridge.setHTML(html);
+    if (warnings.length > 0) {
+      // Surface the first 3 mammoth warnings so the user knows about lost
+      // formatting (tables, footnotes, etc.) without a wall of text.
+      const preview = warnings.slice(0, 3).join('\n');
+      const more = warnings.length > 3 ? `\n... and ${warnings.length - 3} more` : '';
+      await message(`Imported with some unsupported formatting:\n\n${preview}${more}`, {
+        title: 'ante',
+        kind: 'info',
+      });
+    }
+    return;
+  }
+
+  const { header, footer, stripped } = parseHeaderFooter(file.contents);
+  appState.filePath = file.path;
+  appState.headerText = header;
+  appState.footerText = footer;
+  savedSnapshot = stripped;
+  appState.isDirty = false;
+  recentFiles.add(file.path);
+  bridge.setHTML(stripped);
 }
 
 /**
@@ -207,6 +228,26 @@ export async function saveFileAs(bridge: EditorBridge): Promise<void> {
     savedSnapshot = editorHtml;
     appState.isDirty = false;
     recentFiles.add(result.path);
+  } catch (err) {
+    await showError(err);
+  }
+}
+
+/**
+ * Export the current document to a `.docx` file via the native save dialog.
+ * Header / footer text from app state is dropped; DOCX has its own model.
+ */
+export async function exportAsDocx(bridge: EditorBridge): Promise<void> {
+  const editorHtml = bridge.getHTML();
+  const suggestedName = appState.filePath
+    ? appState.filePath.split(/[\\/]/).pop()?.replace(/\.[^./\\]+$/, '.docx') || 'Untitled.docx'
+    : 'Untitled.docx';
+  try {
+    const bytesB64 = await htmlToDocxBytes(editorHtml);
+    await invoke<SaveAsResult>('save_docx_as', {
+      bytesB64,
+      suggestedName,
+    });
   } catch (err) {
     await showError(err);
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,8 +1,7 @@
-/** Payload returned by the open_file Rust command. */
-export interface FilePayload {
-  path: string;
-  contents: string;
-}
+/** Payload returned by the open_file / read_file Rust commands. */
+export type OpenedFile =
+  | { kind: 'text'; path: string; contents: string }
+  | { kind: 'docx'; path: string; bytes_b64: string };
 
 /** Payload returned by the save_file_as Rust command. */
 export interface SaveAsResult {

--- a/src/lib/ui/Toolbar.svelte
+++ b/src/lib/ui/Toolbar.svelte
@@ -10,12 +10,13 @@
     onOpen?: () => void;
     onSave?: () => void;
     onSaveAs?: () => void;
+    onExportDocx?: () => void;
     onToggleSidebar?: () => void;
     onToggleAi?: () => void;
     onInsertImage?: () => void;
   }
 
-  let { editor, onNew, onOpen, onSave, onSaveAs, onToggleSidebar, onToggleAi, onInsertImage }: Props = $props();
+  let { editor, onNew, onOpen, onSave, onSaveAs, onExportDocx, onToggleSidebar, onToggleAi, onInsertImage }: Props = $props();
 
   function setPageSize(e: Event): void {
     appState.pageSize = (e.target as HTMLSelectElement).value as PageSize;
@@ -208,6 +209,18 @@
         <polyline points="14 21 14 13 7 13 7 18"></polyline>
         <polyline points="7 3 7 8 13 8"></polyline>
         <path d="M18.5 14.5l3 3-4 4h-3v-3z"></path>
+      </svg>
+    </button>
+    <button
+      class="toolbar-btn"
+      title="Export as Word (.docx)"
+      onclick={onExportDocx}
+      aria-label="Export as Word document"
+    >
+      <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+        <polyline points="14 2 14 8 20 8"></polyline>
+        <text x="7" y="18" font-family="system-ui, sans-serif" font-size="6" font-weight="700" fill="currentColor" stroke="none">W</text>
       </svg>
     </button>
   </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -16,6 +16,7 @@
     openPath,
     saveFile,
     saveFileAs,
+    exportAsDocx,
     newFile,
     promptUnsavedChanges,
     getSavedSnapshot,
@@ -115,6 +116,10 @@
 
   async function handleSave(): Promise<void> {
     await saveFile(getBridge());
+  }
+
+  async function handleExportDocx(): Promise<void> {
+    await exportAsDocx(getBridge());
   }
 
   async function handleInsertImage(): Promise<void> {
@@ -278,6 +283,7 @@
     onOpen={handleOpen}
     onSave={handleSave}
     onSaveAs={() => saveFileAs(getBridge())}
+    onExportDocx={handleExportDocx}
     onToggleSidebar={() => (appState.sidebarOpen = !appState.sidebarOpen)}
     onToggleAi={toggleAi}
     onInsertImage={handleInsertImage}

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,7 +2,6 @@ import { defineConfig } from "vite";
 import { sveltekit } from "@sveltejs/kit/vite";
 import tailwindcss from "@tailwindcss/vite";
 
-// @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
 
 // https://vite.dev/config/


### PR DESCRIPTION
Closes #18.

## Summary
- Open `.docx` files via the existing Open dialog (mammoth -> HTML -> TipTap)
- Export current document as `.docx` via a new toolbar button (TipTap HTML -> docx.js Document -> binary save)
- Mammoth warnings about unsupported formatting (tables, footnotes, ...) are shown to the user as a non-blocking info dialog

## Architecture
- Rust: replaced \`FilePayload\` with a discriminated \`OpenedFile { Text | Docx }\` payload; \`open_file\` and \`read_file\` smart-route on extension. New \`save_docx_as\` command with a binary-safe atomic writer.
- TS: \`src/lib/io/docx.ts\` owns both directions. Import is a thin mammoth wrapper. Export is a focused HTML->docx walker (~250 LOC) covering the MVP feature set in #18: paragraphs, headings (H1-H6), bold/italic/underline/strike, ul/ol lists, hyperlinks, alignment, font family/size/color.
- Out of scope (per #18): tables, images, footnotes, headers/footers, page breaks. \`<img>\` tags are dropped on export until image-bytes export is wired up.

## Open-source compliance
- mammoth: BSD-2-Clause
- docx: MIT
- Both OSI-approved, MIT-compatible with ante.

## Test plan
- [x] \`pnpm check\` (0 errors)
- [x] \`pnpm build\` (clean, ~8.3s)
- [x] \`cd src-tauri && cargo check --all-targets\`
- [x] \`cd src-tauri && cargo test --lib\` (25/25, +4 new)
- [ ] Manual: open a .docx generated by Word / Google Docs / LibreOffice; verify text + headings + lists + marks render
- [ ] Manual: export a doc; open the resulting .docx in Word and Google Docs; verify it opens cleanly
- [ ] Manual: round-trip (open .docx, no edits, export) stays visually consistent for in-scope features