### PR TITLE
fix(docx): wrap fragments in full <html><body> for spec-leaning parsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@tailwindcss/vite": "^4.2.2",
     "@tauri-apps/cli": "^2",
     "bits-ui": "^2.16.3",
+    "linkedom": "^0.18.12",
     "svelte": "^5.0.0",
     "svelte-check": "^4.0.0",
     "tailwindcss": "^4.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       bits-ui:
         specifier: ^2.16.3
         version: 2.17.3(@internationalized/date@3.12.1)(@sveltejs/kit@2.57.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.4)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)(typescript@5.6.3)(vite@6.4.2(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.4)
+      linkedom:
+        specifier: ^0.18.12
+        version: 0.18.12
       svelte:
         specifier: ^5.0.0
         version: 5.55.4
@@ -871,6 +874,9 @@ packages:
   bluebird@3.4.7:
     resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
 
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
@@ -892,6 +898,16 @@ packages:
 
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
+
+  cssom@0.5.0:
+    resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -924,6 +940,19 @@ packages:
     resolution: {integrity: sha512-ZJja9/KBUuFC109sCMzovoq2GR2wCG/AuxivjA+OHj/q0TEgJIm3S7yrlUxIy3B+bV8YDj/BiHfWyrRFmyWpDQ==}
     engines: {node: '>=10'}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
   duck@0.1.12:
     resolution: {integrity: sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==}
 
@@ -933,6 +962,10 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   esbuild@0.25.12:
@@ -974,6 +1007,12 @@ packages:
 
   hash.js@1.1.7:
     resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
+
+  html-escaper@3.0.3:
+    resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
+
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
 
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
@@ -1074,6 +1113,15 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  linkedom@0.18.12:
+    resolution: {integrity: sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      canvas: '>= 2'
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
 
@@ -1131,6 +1179,9 @@ packages:
 
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
   option@0.2.4:
     resolution: {integrity: sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==}
@@ -1347,6 +1398,9 @@ packages:
 
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
+  uhyphen@0.2.0:
+    resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
 
   underscore@1.13.8:
     resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
@@ -2024,6 +2078,8 @@ snapshots:
 
   bluebird@3.4.7: {}
 
+  boolbase@1.0.0: {}
+
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
@@ -2037,6 +2093,18 @@ snapshots:
   core-util-is@1.0.3: {}
 
   crelt@1.0.6: {}
+
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-what@6.2.2: {}
+
+  cssom@0.5.0: {}
 
   debug@4.4.3:
     dependencies:
@@ -2061,6 +2129,24 @@ snapshots:
       xml: 1.0.1
       xml-js: 1.6.11
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
   duck@0.1.12:
     dependencies:
       underscore: 1.13.8
@@ -2071,6 +2157,8 @@ snapshots:
       tapable: 2.3.2
 
   entities@4.5.0: {}
+
+  entities@7.0.1: {}
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -2122,6 +2210,15 @@ snapshots:
     dependencies:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
+
+  html-escaper@3.0.3: {}
+
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
 
   immediate@3.0.6: {}
 
@@ -2199,6 +2296,14 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  linkedom@0.18.12:
+    dependencies:
+      css-select: 5.2.2
+      cssom: 0.5.0
+      html-escaper: 3.0.3
+      htmlparser2: 10.1.0
+      uhyphen: 0.2.0
+
   linkify-it@5.0.0:
     dependencies:
       uc.micro: 2.1.0
@@ -2256,6 +2361,10 @@ snapshots:
   nanoid@5.1.9: {}
 
   node-fetch-native@1.6.7: {}
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
 
   option@0.2.4: {}
 
@@ -2544,6 +2653,8 @@ snapshots:
   typescript@5.6.3: {}
 
   uc.micro@2.1.0: {}
+
+  uhyphen@0.2.0: {}
 
   underscore@1.13.8: {}
 

--- a/scripts/docx-smoke.mts
+++ b/scripts/docx-smoke.mts
@@ -1,0 +1,110 @@
+// DOCX import/export smoke test for ante.
+//
+// Run with: pnpm dlx tsx scripts/docx-smoke.mts
+//
+// We exercise:
+//   - htmlToDocxBytes (export): TipTap-style HTML -> docx bytes, written to
+//     disk, ZIP magic verified, then read back via mammoth's Node {buffer}
+//     entrypoint and asserted feature-by-feature.
+//   - mammoth import on a textutil-generated .docx: proves we can read
+//     real-world Word output. The thin docxBytesToHtml wrapper isn't called
+//     here because mammoth's Node bundle doesn't accept arrayBuffer (browser
+//     -only API), so we call mammoth the same way the wrapper would.
+
+import { parseHTML } from 'linkedom';
+import mammoth from 'mammoth';
+import fs from 'node:fs';
+import path from 'node:path';
+
+class LinkedomDOMParser {
+  parseFromString(html: string, _type: string) {
+    const { document } = parseHTML(html);
+    return document;
+  }
+}
+// @ts-expect-error injecting browser global into node
+globalThis.DOMParser = LinkedomDOMParser;
+// @ts-expect-error linkedom nodes use numeric nodeType but no Node global
+globalThis.Node = { TEXT_NODE: 3, ELEMENT_NODE: 1 };
+if (!globalThis.atob) {
+  // @ts-expect-error
+  globalThis.atob = (s: string) => Buffer.from(s, 'base64').toString('binary');
+}
+if (!globalThis.btoa) {
+  // @ts-expect-error
+  globalThis.btoa = (s: string) => Buffer.from(s, 'binary').toString('base64');
+}
+
+const anteRoot = '/Users/marc/Code/open-source/ante';
+const docxModule = await import(path.join(anteRoot, 'src/lib/io/docx.ts'));
+const { htmlToDocxBytes } = docxModule;
+
+const SAMPLE_HTML = fs.readFileSync('/tmp/ante-smoke/sample.html', 'utf8');
+
+function check(label: string, ok: boolean): boolean {
+  console.log(`  ${ok ? 'OK  ' : 'FAIL'} ${label}`);
+  return ok;
+}
+
+async function testExportRoundTrip(): Promise<void> {
+  console.log('\n=== EXPORT: sample HTML -> .docx ===');
+  const b64 = await htmlToDocxBytes(SAMPLE_HTML);
+  const buf = Buffer.from(b64, 'base64');
+  const out = '/tmp/ante-smoke/exported.docx';
+  fs.writeFileSync(out, buf);
+  console.log(`  wrote ${out} (${buf.length} bytes)`);
+
+  if (!(buf[0] === 0x50 && buf[1] === 0x4b && buf[2] === 0x03 && buf[3] === 0x04)) {
+    throw new Error('output is not a valid ZIP (no PK magic bytes)');
+  }
+  console.log('  ZIP magic OK');
+
+  console.log('\n=== ROUND-TRIP: read exported.docx via mammoth ===');
+  const result = await mammoth.convertToHtml({ buffer: buf });
+  console.log('  resulting HTML:');
+  console.log(result.value.split('\n').map((l) => '    ' + l).join('\n'));
+  console.log(`  warnings: ${result.messages.length}`);
+
+  const html = result.value;
+  let failed = 0;
+  if (!check('h1 heading',     /<h1[^>]*>[^<]*Ante DOCX Smoke Test/.test(html))) failed++;
+  if (!check('h2 heading',     /<h2[^>]*>[^<]*Subheading/.test(html))) failed++;
+  if (!check('bold survives',  /<strong>bold<\/strong>/.test(html))) failed++;
+  if (!check('italic survives',/<em>italic<\/em>/.test(html))) failed++;
+  if (!check('hyperlink',      /<a href="https:\/\/example\.com">a link<\/a>/.test(html))) failed++;
+  if (!check('bullet list',    /<ul>[\s\S]*First bullet[\s\S]*<\/ul>/.test(html))) failed++;
+  if (!check('numbered list',  /<ol>[\s\S]*One[\s\S]*Two[\s\S]*Three[\s\S]*<\/ol>/.test(html))) failed++;
+  if (failed > 0) throw new Error(`${failed} round-trip assertion(s) failed`);
+}
+
+async function testImportOfRealWordDoc(): Promise<void> {
+  console.log('\n=== IMPORT: textutil-generated .docx -> HTML ===');
+  // Note: macOS textutil emits a flatter DOCX than real Word - it represents
+  // headings as bold paragraphs and bullets as tab-prefixed text rather than
+  // real Heading/List styles. So we only assert that text + inline marks
+  // survive. The round-trip test above is the stronger fidelity proof.
+  const buf = fs.readFileSync('/tmp/ante-smoke/wordlike.docx');
+  const result = await mammoth.convertToHtml({ buffer: buf });
+  console.log('  resulting HTML:');
+  console.log(result.value.split('\n').map((l) => '    ' + l).join('\n'));
+  console.log(`  warnings: ${result.messages.length}`);
+
+  const html = result.value;
+  let failed = 0;
+  if (!check('title text present',   /From Word-ish/.test(html))) failed++;
+  if (!check('bold survived',        /<strong>bold<\/strong>/.test(html))) failed++;
+  if (!check('italic survived',      /<em>italic<\/em>/.test(html))) failed++;
+  if (!check('list items present',   /Alpha[\s\S]*Beta/.test(html))) failed++;
+  if (failed > 0) throw new Error(`${failed} real-Word-doc import assertion(s) failed`);
+}
+
+async function main() {
+  await testExportRoundTrip();
+  await testImportOfRealWordDoc();
+  console.log('\n=== ALL OK ===');
+}
+
+main().catch((e) => {
+  console.error('\n=== FAIL ===\n', e);
+  process.exit(1);
+});

--- a/src/lib/io/docx.ts
+++ b/src/lib/io/docx.ts
@@ -95,7 +95,13 @@ interface RunStyle {
 }
 
 function buildDocument(html: string): Document {
-  const dom = new DOMParser().parseFromString(`<!doctype html><body>${html}</body>`, 'text/html');
+  // Wrap in a complete document. Browser DOMParser auto-creates html/body
+  // from a fragment, but spec-leaning parsers (linkedom, used in tests)
+  // don't, so we hand them everything they need.
+  const dom = new DOMParser().parseFromString(
+    `<!doctype html><html><body>${html}</body></html>`,
+    'text/html',
+  );
   const body = dom.body;
   const children: Paragraph[] = [];
   for (const node of Array.from(body.childNodes)) {


### PR DESCRIPTION
Follow-up to #19. Found via self-test of the DOCX import/export feature.

## Problem
\`buildDocument\` in \`src/lib/io/docx.ts\` was wrapping the input HTML as \`<!doctype html><body>${html}</body>\` and feeding it to DOMParser. Browser DOMParser auto-creates the implied \`<html>\` element so this works at runtime in the Tauri webview. But spec-leaning parsers (linkedom, jsdom in strict modes) don't auto-wrap, so they leave \`document.body\` empty. Without realizing this, the walker traversed nothing and the exporter emitted a single empty paragraph.

The bug never surfaced in production because the only call site is the browser. It surfaced when running the new smoke test in Node.

## Fix
Hand DOMParser a complete \`<!doctype html><html><body>...</body></html>\` document. Browser behavior is unchanged; spec parsers now populate body correctly.

## Smoke test
\`scripts/docx-smoke.mts\` round-trips sample TipTap-style HTML through \`htmlToDocxBytes\` -> mammoth -> regex assertions. Also reads a \`textutil\`-generated DOCX to verify the import side. Run with:

\`\`\`
pnpm dlx tsx scripts/docx-smoke.mts
\`\`\`

Adds \`linkedom@^0.18\` (ISC, ~50KB) as a devDep for the script's DOMParser shim. ISC is OSI-approved and MIT-compatible.

## Test plan
- [x] \`pnpm check\` (0 errors)
- [x] Smoke test passes 7/7 round-trip assertions (h1/h2, bold, italic, hyperlink, ul, ol)
- [x] Smoke test passes 4/4 import assertions on a textutil-generated .docx
- [x] Underline mark verified in DOCX XML (\`<w:u w:val=\"single\"/>\`); mammoth's default config drops it from the HTML view, but real Word/Pages will render it